### PR TITLE
[LOGTOOL-39] readResolve() should return java.lang.Object

### DIFF
--- a/src/main/java/org/jboss/logging/processor/model/ClassModel.java
+++ b/src/main/java/org/jboss/logging/processor/model/ClassModel.java
@@ -268,7 +268,7 @@ public abstract class ClassModel {
         final JDefinedClass definedClass = getDefinedClass();
         final JFieldVar instance = definedClass.field(JMod.PUBLIC | JMod.STATIC | JMod.FINAL, definedClass, INSTANCE_FIELD_NAME);
         instance.init(JExpr._new(definedClass));
-        final JMethod readResolveMethod = definedClass.method(JMod.PROTECTED, definedClass, GET_INSTANCE_METHOD_NAME);
+        final JMethod readResolveMethod = definedClass.method(JMod.PROTECTED, Object.class, GET_INSTANCE_METHOD_NAME);
         readResolveMethod.body()._return(instance);
         return readResolveMethod;
     }


### PR DESCRIPTION
Use java.lang.Object return type for readResolve() methods on message bundles.
