### PR TITLE
[LOGTOOL-77] Use the writer from the JavaFileObject as it doesn't write one byte at a time

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/apt/TranslationFileGenerator.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/TranslationFileGenerator.java
@@ -28,7 +28,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -45,7 +44,6 @@ import javax.lang.model.element.TypeElement;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 
-import org.jboss.logging.annotations.Transform;
 import org.jboss.logging.annotations.Transform.TransformType;
 import org.jboss.logging.processor.model.MessageInterface;
 import org.jboss.logging.processor.model.MessageMethod;
@@ -201,7 +199,9 @@ final class TranslationFileGenerator extends AbstractGenerator {
 
         try {
             final FileObject fileObject = filer().createResource(StandardLocation.CLASS_OUTPUT, messageInterface.packageName(), fileName);
-            writer = new BufferedWriter(new OutputStreamWriter(fileObject.openOutputStream()));
+            // Note the FileObject#openWriter() is used here. The FileObject#openOutputStream() returns an output stream
+            // that writes each byte separately which results in poor performance.
+            writer = new BufferedWriter(fileObject.openWriter());
             // Write comments
             writer.write(Strings.fill("#", DEFAULT_FILE_COMMENT.length()));
             writer.newLine();

--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/JavaFileObjectCodeWriter.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/JavaFileObjectCodeWriter.java
@@ -22,8 +22,10 @@
 
 package org.jboss.logging.processor.generator.model;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 import javax.tools.JavaFileObject;
 
 import org.jboss.jdeparser.CodeWriter;
@@ -51,11 +53,6 @@ class JavaFileObjectCodeWriter extends CodeWriter {
     private final JavaFileObject fileObject;
 
     /**
-     * The output stream.
-     */
-    private OutputStream out;
-
-    /**
      * Class constructor.
      *
      * @param fileObject the file object.
@@ -70,15 +67,19 @@ class JavaFileObjectCodeWriter extends CodeWriter {
      */
     @Override
     public OutputStream openBinary(final JPackage pkg, final String fileName) throws IOException {
-        this.out = fileObject.openOutputStream();
-        return out;
+        // No reason to wrap in a buffer as the FileObject returns a FilterOutputStream which writes a byte at a time
+        return fileObject.openOutputStream();
+    }
+
+    @Override
+    public Writer openSource(final JPackage pkg, final String fileName) throws IOException {
+        // At least in OpenJDK encoding is correctly handled in the implementation
+        return new BufferedWriter(fileObject.openWriter());
     }
 
     @Override
     public void close() throws IOException {
-        if (out != null) {
-            out.close();
-        }
+        // no-op
     }
 
 }


### PR DESCRIPTION
Found the implementation of `javax.tools.JavaFileObject#openOutputStream` returns `com.sun.tools.javac.processing.JavacFiler$FilerOutputStream` which extends `FilterOutputStream`. This writes a single byte at a time resulting in poor performance.
