### PR TITLE
[LOGTOOL-85] Suppress all warning in generated code.

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/ClassModel.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/ClassModel.java
@@ -131,6 +131,10 @@ public abstract class ClassModel {
         generatedAnnotation.param("value", getClass().getName());
         generatedAnnotation.param("date", ClassModelHelper.generatedDateValue());
 
+        // Suppress all warnings: all for Eclipse, rawtypes & unchecked for javac
+        JAnnotationUse suppressWarningsAnnotation = definedClass.annotate(SuppressWarnings.class);
+        suppressWarningsAnnotation.paramArray("value").param("all").param("rawtypes").param("unchecked");
+
         // Create the default JavaDoc
         JDocComment docComment = definedClass.javadoc();
         docComment.add("Warning this class consists of generated code.");


### PR DESCRIPTION
Generated logger/messages implementaions may cause the compiler to emit warnings (for example, if your interface method has generic parameters). It will be a problem if you compile with -Xlint:all -Werror flags.
I suppose there is no real reason to make the processor honour generics, and these warnings can be safely ignored?