### PR TITLE
Introduce the capability to log stack traces only at certain levels.

### DIFF
--- a/annotations/src/main/java/org/jboss/logging/annotations/Cause.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Cause.java
@@ -19,6 +19,8 @@
 
 package org.jboss.logging.annotations;
 
+import org.jboss.logging.Logger;
+
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
@@ -35,4 +37,17 @@ import java.lang.annotation.Target;
 @Target(PARAMETER)
 @Documented
 public @interface Cause {
+    /**
+     * The maximum allowed log level at which the exception cause is actually logged.
+     *
+     * This level is compared against the log level allowed for the logger, i.e. it is independent of the level the
+     * actual message is being logged at.
+     *
+     * The default value, {@link org.jboss.logging.Logger.Level#FATAL} means that the cause is attached to the message
+     * every time.
+     *
+     * If this attribute is set for example to {@link Logger.Level#DEBUG} then the cause will be attached to the message
+     * only if the allowed log level for the logger is {@link Logger.Level#DEBUG} or {@link Logger.Level#TRACE}.
+     */
+    Logger.Level loggedAt() default Logger.Level.FATAL;
 }

--- a/processor/src/main/java/org/jboss/logging/processor/apt/MessageMethodBuilder.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/MessageMethodBuilder.java
@@ -56,6 +56,7 @@ import org.jboss.logging.processor.model.ReturnType;
 import org.jboss.logging.processor.model.ThrowableType;
 import org.jboss.logging.processor.util.Comparison;
 import org.jboss.logging.processor.util.ElementHelper;
+import org.jboss.logging.processor.util.LogLevelHelper;
 
 /**
  * Date: 29.07.2011
@@ -314,7 +315,7 @@ final class MessageMethodBuilder {
             // TODO (jrp) possibly return the actual level
             final LogMessage logMessage = method.getAnnotation(LogMessage.class);
             final Logger.Level logLevel = (logMessage.level() == null ? Logger.Level.INFO : logMessage.level());
-            return String.format("%s.%s.%s", Logger.class.getName(), Logger.Level.class.getSimpleName(), logLevel.name());
+            return LogLevelHelper.toString(logLevel);
         }
 
         @Override

--- a/processor/src/main/java/org/jboss/logging/processor/apt/ParameterFactory.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/ParameterFactory.java
@@ -118,6 +118,11 @@ final class ParameterFactory {
             }
 
             @Override
+            public Cause cause() {
+                return null;
+            }
+
+            @Override
             public String type() {
                 return String.class.getName();
             }
@@ -212,6 +217,7 @@ final class ParameterFactory {
         private final ParameterType parameterType;
         private final Transform transform;
         private final Pos pos;
+        private final Cause cause;
 
         /**
          * Only allow construction from within the parent class.
@@ -233,41 +239,49 @@ final class ParameterFactory {
                 parameterType = ParameterType.CONSTRUCTION;
                 transform = null;
                 pos = null;
+                cause = null;
             } else if (ElementHelper.isAnnotatedWith(param, Cause.class)) {
                 paramClass = null;
                 parameterType = ParameterType.CAUSE;
                 transform = null;
                 pos = null;
+                cause = param.getAnnotation(Cause.class);
             } else if (ElementHelper.isAnnotatedWith(param, Field.class)) {
                 paramClass = null;
                 parameterType = ParameterType.FIELD;
                 transform = null;
                 pos = null;
+                cause = null;
             } else if (ElementHelper.isAnnotatedWith(param, Property.class)) {
                 paramClass = null;
                 parameterType = ParameterType.PROPERTY;
                 transform = null;
                 pos = null;
+                cause = null;
             } else if (ElementHelper.isAnnotatedWith(param, LoggingClass.class)) {
                 paramClass = null;
                 parameterType = ParameterType.FQCN;
                 transform = null;
                 pos = null;
+                cause = null;
             } else if (ElementHelper.isAnnotatedWith(param, Transform.class)) {
                 paramClass = null;
                 parameterType = ParameterType.TRANSFORM;
                 transform = param.getAnnotation(Transform.class);
                 pos = null;
+                cause = null;
             } else if (ElementHelper.isAnnotatedWith(param, Pos.class)) {
                 paramClass = null;
                 parameterType = ParameterType.POS;
                 transform = null;
                 pos = param.getAnnotation(Pos.class);
+                cause = null;
             } else {
                 parameterType = ParameterType.FORMAT;
                 paramClass = null;
                 transform = null;
                 pos = null;
+                cause = null;
             }
             this.isVarArgs = isVarArgs;
         }
@@ -344,6 +358,11 @@ final class ParameterFactory {
         @Override
         public Pos pos() {
             return pos;
+        }
+
+        @Override
+        public Cause cause() {
+            return cause;
         }
 
         @Override

--- a/processor/src/main/java/org/jboss/logging/processor/model/Parameter.java
+++ b/processor/src/main/java/org/jboss/logging/processor/model/Parameter.java
@@ -22,6 +22,7 @@
 
 package org.jboss.logging.processor.model;
 
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Pos;
 import org.jboss.logging.annotations.Transform;
 
@@ -176,4 +177,11 @@ public interface Parameter extends Comparable<Parameter>, MessageObjectType {
      * @return the position annotation or {@code null} if not a position parameter
      */
     Pos pos();
+
+    /**
+     * The cause annotation if the {@link #parameterType()} is {@link ParameterType#CAUSE}.
+     *
+     * @return the cause annotation or {@code null} if not a cause parameter
+     */
+    Cause cause();
 }

--- a/processor/src/main/java/org/jboss/logging/processor/util/LogLevelHelper.java
+++ b/processor/src/main/java/org/jboss/logging/processor/util/LogLevelHelper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.logging.processor.util;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author Lukas Krejci
+ */
+public final class LogLevelHelper {
+    private LogLevelHelper() {
+
+    }
+
+    public static String toString(Logger.Level level) {
+        return String.format("%s.%s.%s", Logger.class.getName(), Logger.Level.class.getSimpleName(), level.name());
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/DefaultLogger.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/DefaultLogger.java
@@ -78,6 +78,10 @@ interface DefaultLogger extends BasicLogger {
     @Message(id = Message.INHERIT, value = "Invalid value '%s'. Valid values are; %s")
     void invalidSelection(String selected, String[] validValues);
 
+    @LogMessage(level  = Level.INFO)
+    @Message(id = 106, value = TEST_MSG)
+    void causeWithLoggedAt(@Cause(loggedAt = Level.DEBUG) Throwable cause);
+
     static class CustomFormatter {
 
         private final String msg;

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MessageListHandler.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MessageListHandler.java
@@ -37,7 +37,11 @@ class MessageListHandler extends ExtHandler {
     @Override
     protected void doPublish(final ExtLogRecord record) {
         super.doPublish(record);
-        messages.add(record.getFormattedMessage());
+        String message = record.getFormattedMessage();
+        if (record.getThrown() != null) {
+            message += " EXCEPTION: " + record.getThrown().getClass().getName();
+        }
+        messages.add(message);
     }
 
     String getMessage(final int index) {


### PR DESCRIPTION
The rationale for wanting this feature is that usually the readers of the
log are not exactly interested in the stack traces unless they are
developers (which, most of the time, they are not).

Stacktraces fill up the log and occlude the possibly important messages
in "cruft".

Therefore it would be nice to NOT log stack traces by default but enable
the logging system to do so on demand.

The imagined workflow goes like this:

1) User encounters a strange message in the logs.
2) User calls up support.
3) Support doesn't know how this should be solved, calls up the developer.
4) Developer is not sure how this could happen and would like to see the
stacktrace.
5) Support asks the user to switch on the debug logging on a certain
logger and replicate the issue.
6) All of the sudden the stack traces appear along with the very same
messages without the need to change the code.
7) Developer sees what he wanted, fixes the issue.
