### PR TITLE
[LOGTOOL-95] Use super.log when extending the DelegatingBasicLogger t…

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/MessageLoggerImplementor.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/MessageLoggerImplementor.java
@@ -129,7 +129,7 @@ final class MessageLoggerImplementor extends ImplementationClassModel {
                 sourceFile._import(DelegatingBasicLogger.class);
                 classDef._extends(DelegatingBasicLogger.class);
                 constructorBody.callSuper().arg($v(constructorParam));
-                logger = $v(constructorParam);
+                logger = $v("super").field("log");
             } else {
                 JVarDeclaration logVar = classDef.field(JMod.PROTECTED | JMod.FINAL, loggerType, LOG_FIELD_NAME);
                 constructorBody.assign(THIS.field(logVar.name()), $v(constructorParam));

--- a/processor/src/test/java/org/jboss/logging/processor/generated/DefaultLogger.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/DefaultLogger.java
@@ -50,6 +50,9 @@ interface DefaultLogger extends BasicLogger {
      */
     DefaultLogger LOGGER = Logger.getMessageLogger(DefaultLogger.class, AbstractLoggerTest.CATEGORY);
 
+    // Used to test the ambiguous log field in the DelegatingBasicLogger
+    DefaultLogger log = Logger.getMessageLogger(DefaultLogger.class, AbstractLoggerTest.CATEGORY);
+
     @LogMessage(level = Level.INFO)
     @Message(id = 100, value = "Hello %s.")
     void hello(String name);


### PR DESCRIPTION
…o avoid ambiguous field names if the interface being implemented also contains a field named log.