### PR TITLE
[LOGTOOL-105] Attempt to determine which Generated annotation to use.…

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/apt/LoggingToolsProcessor.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/LoggingToolsProcessor.java
@@ -87,6 +87,7 @@ public class LoggingToolsProcessor extends AbstractProcessor {
 
     public static final String DEBUG_OPTION = "debug";
     static final String EXPRESSION_PROPERTIES = "expressionProperties";
+    static final String ADD_GENERATED_ANNOTATION = "addGeneratedAnnotation";
     private final List<String> interfaceAnnotations = Arrays.asList(MessageBundle.class.getName(), MessageLogger.class.getName());
     private final List<AbstractGenerator> generators;
     private final Set<String> supportedAnnotations;
@@ -184,6 +185,7 @@ public class LoggingToolsProcessor extends AbstractProcessor {
                 }
             }
         }
+        final boolean addGeneratedAnnotation = Boolean.parseBoolean(processingEnv.getOptions().getOrDefault(ADD_GENERATED_ANNOTATION, "true"));
         boolean generate = true;
         final Validator validator = new Validator(processingEnv);
 
@@ -195,7 +197,7 @@ public class LoggingToolsProcessor extends AbstractProcessor {
                     final Set<? extends TypeElement> interfaces = typesIn(roundEnv.getElementsAnnotatedWith(annotation));
                     for (TypeElement interfaceElement : interfaces) {
                         try {
-                            final MessageInterface messageInterface = MessageInterfaceFactory.of(processingEnv, interfaceElement, expressionProperties);
+                            final MessageInterface messageInterface = MessageInterfaceFactory.of(processingEnv, interfaceElement, expressionProperties, addGeneratedAnnotation);
                             final Collection<ValidationMessage> validationMessages = validator.validate(messageInterface);
                             for (ValidationMessage message : validationMessages) {
                                 if (message.printMessage(processingEnv.getMessager())) {

--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/ClassModel.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/ClassModel.java
@@ -33,8 +33,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import javax.annotation.Generated;
 import javax.annotation.processing.Filer;
+import javax.lang.model.element.TypeElement;
 
 import org.jboss.jdeparser.FormatPreferences;
 import org.jboss.jdeparser.JCall;
@@ -135,12 +135,15 @@ public abstract class ClassModel {
      * @throws IllegalStateException if the class has already been defined.
      */
     JClassDef generateModel() throws IllegalStateException {
-        // Add generated annotation
-        final JType generatedType = $t(Generated.class);
-        sourceFile._import(generatedType);
-        classDef.annotate(generatedType)
-                .value("value", getClass().getName())
-                .value("date", JExprs.str(ClassModelHelper.generatedDateValue()));
+        // Add generated annotation if required
+        final TypeElement generatedAnnotation = messageInterface.generatedAnnotation();
+        if (generatedAnnotation != null) {
+            final JType generatedType = typeOf(generatedAnnotation.asType());
+            sourceFile._import(generatedType);
+            classDef.annotate(generatedType)
+                    .value("value", getClass().getName())
+                    .value("date", JExprs.str(ClassModelHelper.generatedDateValue()));
+        }
 
         // Create the default JavaDoc
         classDef.docComment().text("Warning this class consists of generated code.");

--- a/processor/src/main/java/org/jboss/logging/processor/model/MessageInterface.java
+++ b/processor/src/main/java/org/jboss/logging/processor/model/MessageInterface.java
@@ -25,6 +25,7 @@ package org.jboss.logging.processor.model;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import javax.lang.model.element.TypeElement;
 
 import org.jboss.logging.annotations.MessageBundle;
 import org.jboss.logging.annotations.MessageLogger;
@@ -110,4 +111,14 @@ public interface MessageInterface extends Comparable<MessageInterface>, ClassTyp
      * @return the length to pad the id with
      */
     int getIdLength();
+
+    /**
+     * Returns the type to use for the {@code @Generated} annotation. This may return {@code null} of the implementation
+     * should not be annotated.
+     *
+     * @return the type for the generated annotation or {@code null} if no annotation is wanted
+     */
+    default TypeElement generatedAnnotation() {
+        return null;
+    }
 }


### PR DESCRIPTION
… If neither can be used just ignore the annotation.

In Java 9 the `@Generated` annotation was moved to the `javax.annotation.processing` package. This change first tries the `javax.annotation.Generated` annotation and if not found uses the `javax.annotation.processing.Generated` annotation. If neither annotation is not found no annotation will be used on the generate source.

Also added option `addGeneratedAnnotation` which defaults to `true`, but when set to `false` will not attempt to add any `@Generated` annotation to the generated source.