### PR TITLE
Minor updates to reports

### DIFF
--- a/docs/src/main/asciidoc/reports.adoc
+++ b/docs/src/main/asciidoc/reports.adoc
@@ -1,7 +1,7 @@
 
 == Reports
 
-There are currently two types of reports that can be generated. The options are `adoc` for asciidoc and `xml` for XML.
+There are currently two types of reports that can be generated. The options are `adoc` or `asciidoc` for asciidoc and `xml` for XML.
 
 The reports contain the following data:
 

--- a/processor/src/main/java/org/jboss/logging/processor/apt/ReportFileGenerator.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/ReportFileGenerator.java
@@ -74,9 +74,9 @@ public class ReportFileGenerator extends AbstractGenerator {
             this.reportType = null;
         } else {
             final String s = reportType.toLowerCase(Locale.ROOT);
-            if ("adoc".equalsIgnoreCase(s)) {
+            if ("adoc".equals(s) || "asciidoc".equals(s)) {
                 this.reportType = ReportType.ASCIIDOC;
-            } else if ("xml".equalsIgnoreCase(s)) {
+            } else if ("xml".equals(s)) {
                 this.reportType = ReportType.XML;
             } else {
                 this.reportType = null;

--- a/processor/src/main/java/org/jboss/logging/processor/apt/ReportFileGenerator.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/ReportFileGenerator.java
@@ -117,7 +117,7 @@ public class ReportFileGenerator extends AbstractGenerator {
 
     private BufferedWriter createWriter(final String packageName, final String fileName) throws IOException {
         if (reportPath == null) {
-            return new BufferedWriter(processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, packageName, fileName).openWriter());
+            return new BufferedWriter(processingEnv.getFiler().createResource(StandardLocation.SOURCE_OUTPUT, packageName, fileName).openWriter());
         }
         final Path outputPath = Paths.get(reportPath, packageName.replace(".", FileSystems.getDefault().getSeparator()), fileName);
         Files.createDirectories(outputPath.getParent());

--- a/processor/src/main/java/org/jboss/logging/processor/apt/report/AsciidocReportWriter.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/report/AsciidocReportWriter.java
@@ -43,18 +43,25 @@ class AsciidocReportWriter extends ReportWriter {
     @Override
     public void writeHeader(final String title) throws IOException {
         // Write the title for the document
-        writer.write("= ");
+        final String escapedTitle;
         if (title != null) {
-            writer.write(escape(title).toString());
+            escapedTitle = escape(title).toString();
         } else {
-            writer.write("Messages");
+            escapedTitle = "Messages";
+        }
+        writer.write(escapedTitle);
+        writer.newLine();
+        for (int i = 0; i < escapedTitle.length(); i++) {
+            writer.append('=');
         }
         writer.newLine();
         writer.newLine();
 
-        // Write the table header
         // Write the table title
         writer.append('.').append(messageInterface.name());
+        writer.newLine();
+        // Write the table configuration, 4 columns
+        writer.write("[cols=\"1,5,^1,2m\"]");
         writer.newLine();
         // Write the table header
         writer.write("|===");

--- a/processor/src/main/java/org/jboss/logging/processor/apt/report/ReportWriter.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/report/ReportWriter.java
@@ -40,7 +40,7 @@ import org.jboss.logging.processor.util.Expressions;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public abstract class ReportWriter implements Closeable {
-    static final String DEFAULT_ID = "";
+    static final String DEFAULT_ID = "--";
 
     private final String baseUrl;
     final MessageInterface messageInterface;


### PR DESCRIPTION
Default the report output to be in the source output.

Make some minor tweaks to the generated asciidoc reports. Also allow either {{adoc}} or {{asciidoc}} to be used as the type name for an asciidoc report.