### PR TITLE
[LOGTOOL-125] Move from testng to junit.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <version.org.jboss.logging>3.1.2.GA</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.0.3.Final</version.org.jboss.logmanager>
         <verion.org.jboss.forge.roaster>2.19.2.Final</verion.org.jboss.forge.roaster>
-        <version.org.testng>6.3.1</version.org.testng>
+        <version.junit>4.12</version.junit>
     </properties>
 
     <licenses>
@@ -110,9 +110,10 @@
             </dependency>
 
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${version.org.testng}</version>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.junit}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/processor-tests/pom.xml
+++ b/processor-tests/pom.xml
@@ -64,8 +64,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -78,8 +78,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/processor/src/test/java/org/jboss/logging/processor/generated/AbstractLoggerTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/AbstractLoggerTest.java
@@ -25,8 +25,8 @@ package org.jboss.logging.processor.generated;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>

--- a/processor/src/test/java/org/jboss/logging/processor/generated/ExpressionMessagesTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/ExpressionMessagesTest.java
@@ -22,16 +22,16 @@
 
 package org.jboss.logging.processor.generated;
 
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public class ExpressionMessagesTest extends AbstractLoggerTest {
 
-    @AfterMethod
+    @After
     public void clearHandler() {
         HANDLER.close();
     }
@@ -39,12 +39,12 @@ public class ExpressionMessagesTest extends AbstractLoggerTest {
     @Test
     public void testExpressions() throws Exception {
         ExpressionLogger.LOGGER.logProperty();
-        Assert.assertEquals(HANDLER.getMessage(), "test property value");
+        Assert.assertEquals("test property value", HANDLER.getMessage());
 
         ExpressionLogger.LOGGER.logPropertyDefault();
-        Assert.assertEquals(HANDLER.getMessage(), "default value");
+        Assert.assertEquals("default value", HANDLER.getMessage());
 
-        Assert.assertEquals(ExpressionLogger.LOGGER.property(), "test property value");
-        Assert.assertEquals(ExpressionLogger.LOGGER.propertyDefault(), "default value");
+        Assert.assertEquals("test property value", ExpressionLogger.LOGGER.property());
+        Assert.assertEquals("default value", ExpressionLogger.LOGGER.propertyDefault());
     }
 }

--- a/processor/src/test/java/org/jboss/logging/processor/generated/GeneratedSourceAnalysisTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/GeneratedSourceAnalysisTest.java
@@ -47,9 +47,9 @@ import org.jboss.forge.roaster.model.source.MethodSource;
 import org.jboss.forge.roaster.model.source.ParameterSource;
 import org.jboss.logging.DelegatingBasicLogger;
 import org.jboss.logging.Logger;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -113,13 +113,13 @@ public class GeneratedSourceAnalysisTest {
     public void testRootLocale() throws Exception {
         JavaClassSource implementationSource = parseGenerated(RootLocaleLogger.class);
         FieldSource<JavaClassSource> locale = implementationSource.getField("LOCALE");
-        Assert.assertNotNull(locale, "Expected a LOCALE field for " + implementationSource.getName());
-        Assert.assertEquals(locale.getLiteralInitializer(), "Locale.forLanguageTag(\"en-UK\")");
+        Assert.assertNotNull("Expected a LOCALE field for " + implementationSource.getName(), locale);
+        Assert.assertEquals("Locale.forLanguageTag(\"en-UK\")", locale.getLiteralInitializer());
 
         implementationSource = parseGenerated(DefaultLogger.class);
         locale = implementationSource.getField("LOCALE");
-        Assert.assertNotNull(locale, "Expected a LOCALE field for " + implementationSource.getName());
-        Assert.assertEquals(locale.getLiteralInitializer(), "Locale.ROOT");
+        Assert.assertNotNull("Expected a LOCALE field for " + implementationSource.getName(), locale);
+        Assert.assertEquals("Locale.ROOT", locale.getLiteralInitializer());
     }
 
     private void compareLogger(final Class<?> intf) throws IOException {
@@ -130,19 +130,20 @@ public class GeneratedSourceAnalysisTest {
         // Logger implementations should have a single constructor which accepts a org.jboss.logging.Logger
         final List<MethodSource<JavaClassSource>> implementationMethods = implementationSource.getMethods();
         final Optional<MethodSource<JavaClassSource>> constructor = findConstructor(implementationMethods);
-        Assert.assertTrue(constructor.isPresent(), "No constructor found for " + implementationSource.getName());
+        Assert.assertTrue("No constructor found for " + implementationSource.getName(), constructor.isPresent());
         final List<ParameterSource<JavaClassSource>> parameters = constructor.get().getParameters();
-        Assert.assertEquals(parameters.size(), 1, "Found more than one parameter for " + implementationSource.getName() + ": " + parameters);
+        Assert.assertEquals("Found more than one parameter for " + implementationSource.getName() + ": " + parameters,
+                1, parameters.size());
         final ParameterSource<JavaClassSource> parameter = parameters.get(0);
         final Type<JavaClassSource> type = parameter.getType();
-        Assert.assertEquals(type.getQualifiedName(), Logger.class.getName());
+        Assert.assertEquals(Logger.class.getName(), type.getQualifiedName());
 
         // If the logger is not extending the DelegatingBasicLogger there should be a protected final org.jboss.logging.Logger field
         if (!DelegatingBasicLogger.class.getName().equals(implementationSource.getSuperType())) {
             final FieldSource<JavaClassSource> log = implementationSource.getField("log");
-            Assert.assertNotNull(log, "Expected a log field in " + implementationSource.getName());
-            Assert.assertTrue(log.isProtected() && log.isFinal(),
-                    "Expected the log field to be protected and final in " + implementationSource.getName());
+            Assert.assertNotNull("Expected a log field in " + implementationSource.getName(), log);
+            Assert.assertTrue("Expected the log field to be protected and final in " + implementationSource.getName(),
+                    log.isProtected() && log.isFinal());
         }
     }
 
@@ -153,16 +154,16 @@ public class GeneratedSourceAnalysisTest {
 
         // Message bundles should have an INSTANCE field
         final FieldSource<JavaClassSource> instance = implementationSource.getField("INSTANCE");
-        Assert.assertNotNull(instance, "Expected an INSTANCE field in " + implementationSource.getName());
-        Assert.assertTrue(instance.isStatic() && instance.isFinal() && instance.isPublic(),
-                "Expected the instance field to be public, static and final in " + implementationSource.getName());
+        Assert.assertNotNull("Expected an INSTANCE field in " + implementationSource.getName(), instance);
+        Assert.assertTrue("Expected the instance field to be public, static and final in " + implementationSource.getName(),
+                instance.isStatic() && instance.isFinal() && instance.isPublic());
 
         // Expect a protected constructor with no parameters
         final Optional<MethodSource<JavaClassSource>> constructor = findConstructor(implementationSource.getMethods());
-        Assert.assertTrue(constructor.isPresent(), "No constructor found for " + implementationSource.getName());
+        Assert.assertTrue("No constructor found for " + implementationSource.getName(), constructor.isPresent());
         final MethodSource<JavaClassSource> c = constructor.get();
-        Assert.assertTrue(c.getParameters().isEmpty(), "Expected the constructor parameters to be empty for " + implementationSource.getName());
-        Assert.assertTrue(c.isProtected(), "Expected the constructor to be protected for " + implementationSource.getName());
+        Assert.assertTrue("Expected the constructor parameters to be empty for " + implementationSource.getName(), c.getParameters().isEmpty());
+        Assert.assertTrue("Expected the constructor to be protected for " + implementationSource.getName(), c.isProtected());
     }
 
     private void compareCommon(final JavaInterfaceSource interfaceSource, final JavaClassSource implementationSource) {
@@ -172,18 +173,18 @@ public class GeneratedSourceAnalysisTest {
         // Validate the implementation has all the interface methods, note this should be the cause
         final Collection<String> interfaceMethodNames = toNames(interfaceMethods);
         final Collection<String> implementationMethodNames = toNames(implementationMethods);
-        Assert.assertTrue(implementationMethodNames.containsAll(interfaceMethodNames),
-                String.format("Implementation is missing methods from the interface:%n\timplementation: %s%n\tinterface:%s", implementationMethodNames, interfaceMethodNames));
+        Assert.assertTrue(String.format("Implementation is missing methods from the interface:%n\timplementation: %s%n\tinterface:%s", implementationMethodNames, interfaceMethodNames),
+                implementationMethodNames.containsAll(interfaceMethodNames));
 
         // The generates source files should have a serialVersionUID with a value of one
-        Assert.assertTrue(implementationSource.hasField("serialVersionUID"), "Expected a serialVersionUID field in " + implementationSource.getName());
+        Assert.assertTrue("Expected a serialVersionUID field in " + implementationSource.getName(), implementationSource.hasField("serialVersionUID"));
         final FieldSource<JavaClassSource> serialVersionUID = implementationSource.getField("serialVersionUID");
-        Assert.assertEquals(serialVersionUID.getLiteralInitializer(), "1L", "Expected serialVersionUID  to be set to 1L in " + implementationSource.getName());
+        Assert.assertEquals("Expected serialVersionUID  to be set to 1L in " + implementationSource.getName(), "1L", serialVersionUID.getLiteralInitializer());
 
         // All bundles should have a getLoggingLocale()
         final MethodSource<JavaClassSource> getLoggingLocale = implementationSource.getMethod("getLoggingLocale");
-        Assert.assertNotNull(getLoggingLocale, "Expected a getLoggingLocale() method in " + implementationSource.getName());
-        Assert.assertTrue(getLoggingLocale.isProtected(), "Expected the getLoggingLocale() to be protected in " + implementationSource.getName());
+        Assert.assertNotNull("Expected a getLoggingLocale() method in " + implementationSource.getName(), getLoggingLocale);
+        Assert.assertTrue("Expected the getLoggingLocale() to be protected in " + implementationSource.getName(), getLoggingLocale.isProtected());
     }
 
     private void compareTranslations(final Class<?> intf) throws IOException {
@@ -209,20 +210,20 @@ public class GeneratedSourceAnalysisTest {
                 found.add(method.getName());
             }
         }
-        Assert.assertTrue(found.isEmpty(), "Found methods in implementation that were in the interface " + implementationSource.getName() + " : " + found);
+        Assert.assertTrue("Found methods in implementation that were in the interface " + implementationSource.getName() + " : " + found, found.isEmpty());
 
         // The getLoggerLocale() should be overridden
         final MethodSource<JavaClassSource> getLoggerLocale = implementationSource.getMethod("getLoggingLocale");
-        Assert.assertNotNull(getLoggerLocale, "Missing overridden getLoggingLocale() method " + implementationSource.getName());
+        Assert.assertNotNull("Missing overridden getLoggingLocale() method " + implementationSource.getName(), getLoggerLocale);
 
         // If the file should have a locale constant, validate the constant is one of the Locale constants
         LOCALE_CONSTANTS.forEach((locale, constant) -> {
             if (implementationSource.getName().endsWith(locale.toString())) {
                 // Get the LOCALE field
                 final FieldSource<JavaClassSource> localeField = implementationSource.getField("LOCALE");
-                Assert.assertNotNull(localeField, "Expected a LOCALE field " + implementationSource.getName());
-                Assert.assertEquals(localeField.getLiteralInitializer(), constant,
-                        "Expected the LOCALE to be set to " + constant + " in " + implementationSource.getName());
+                Assert.assertNotNull("Expected a LOCALE field " + implementationSource.getName(), localeField);
+                Assert.assertEquals("Expected the LOCALE to be set to " + constant + " in " + implementationSource.getName(), constant,
+                        localeField.getLiteralInitializer());
             }
         });
 
@@ -236,16 +237,12 @@ public class GeneratedSourceAnalysisTest {
         // All methods in the translation implementation should be overrides of methods in the super class
         implementationSource.getMethods().forEach(method -> {
             if (!method.isConstructor()) {
-                Assert.assertTrue(method.hasAnnotation(Override.class), String.format("Expected method %s to be overridden in %s.",
-                        method.getName(), implementationSource.getName()));
-                Assert.assertTrue(superMethods.contains(method.getName()), String.format("Expected method %s to override the super (%s) method in %s.",
-                        method.getName(), superImplementationSource.getName(), implementationSource.getName()));
+                Assert.assertTrue(String.format("Expected method %s to be overridden in %s.",
+                        method.getName(), implementationSource.getName()), method.hasAnnotation(Override.class));
+                Assert.assertTrue(String.format("Expected method %s to override the super (%s) method in %s.",
+                        method.getName(), superImplementationSource.getName(), implementationSource.getName()), superMethods.contains(method.getName()));
             }
         });
-    }
-
-    private void compareRootLocale(final Class<?> intf, final String expectedLocaleString) throws IOException {
-        final JavaClassSource implementationSource = parseGenerated(intf);
     }
 
     private Optional<MethodSource<JavaClassSource>> findConstructor(final List<MethodSource<JavaClassSource>> implementationMethods) {
@@ -275,8 +272,8 @@ public class GeneratedSourceAnalysisTest {
         final File dir = new File(TEST_GENERATED_SRC_PATH, packageToPath(intf.getPackage()));
         final File[] files = dir.listFiles(filter);
         // There should only be one file
-        Assert.assertNotNull(files, "Did not find any implementation files for interface " + intf.getName());
-        Assert.assertEquals(1, files.length, "Found more than one implementation for interface " + intf.getName() + " " + Arrays.asList(files));
+        Assert.assertNotNull("Did not find any implementation files for interface " + intf.getName(), files);
+        Assert.assertEquals("Found more than one implementation for interface " + intf.getName() + " " + Arrays.asList(files), 1, files.length);
 
         return Roaster.parse(JavaClassSource.class, files[0]);
     }
@@ -288,8 +285,8 @@ public class GeneratedSourceAnalysisTest {
         final File dir = new File(TEST_GENERATED_SRC_PATH, packageToPath(intf.getPackage()));
         final File[] files = dir.listFiles(filter);
         // There should only be one file
-        Assert.assertNotNull(files, "Did not find any implementation files for interface " + intf.getName());
-        Assert.assertTrue(files.length > 0, "Did not find any translation implementations for interface " + intf.getName());
+        Assert.assertNotNull("Did not find any implementation files for interface " + intf.getName(), files);
+        Assert.assertTrue("Did not find any translation implementations for interface " + intf.getName(), files.length > 0);
         final Collection<JavaClassSource> result = new ArrayList<>();
         for (final File file : files) {
             result.add(Roaster.parse(JavaClassSource.class, file));

--- a/processor/src/test/java/org/jboss/logging/processor/generated/LevelIdCheckTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/LevelIdCheckTest.java
@@ -22,16 +22,16 @@
 
 package org.jboss.logging.processor.generated;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public class LevelIdCheckTest extends AbstractLoggerTest {
 
-    @AfterMethod
+    @After
     public void clearHandler() {
         HANDLER.close();
     }
@@ -42,10 +42,10 @@ public class LevelIdCheckTest extends AbstractLoggerTest {
         ValidLogger.LOGGER.processingError(new IllegalArgumentException());
         ValidLogger.LOGGER.processingError(new IllegalArgumentException(), "generated");
         ValidLogger.LOGGER.processingError(this, "invalid reference");
-        Assert.assertEquals(parseLoggerId(HANDLER.getMessage()), 203);
-        Assert.assertEquals(parseLoggerId(HANDLER.getMessage()), 203);
-        Assert.assertEquals(parseLoggerId(HANDLER.getMessage()), 203);
-        Assert.assertEquals(parseLoggerId(HANDLER.getMessage()), 203);
+        Assert.assertEquals(203, parseLoggerId(HANDLER.getMessage()));
+        Assert.assertEquals(203, parseLoggerId(HANDLER.getMessage()));
+        Assert.assertEquals(203, parseLoggerId(HANDLER.getMessage()));
+        Assert.assertEquals(203, parseLoggerId(HANDLER.getMessage()));
     }
 
 

--- a/processor/src/test/java/org/jboss/logging/processor/generated/LogOnceTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/LogOnceTest.java
@@ -29,16 +29,19 @@ import java.util.List;
 import java.util.Map;
 
 import org.jboss.logging.Logger;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class LogOnceTest extends AbstractLoggerTest {
 
-    @AfterMethod
+    @After
     public void clearHandler() {
         HANDLER.close();
     }
@@ -47,25 +50,25 @@ public class LogOnceTest extends AbstractLoggerTest {
     public void logOnce() throws Exception {
         LogOnceLogger.LOGGER.deprecated("test.property");
         LogOnceLogger.LOGGER.deprecated("test.property");
-        Assert.assertEquals(HANDLER.size(), 1, "Only one message should have been logged");
+        Assert.assertEquals("Only one message should have been logged", 1, HANDLER.size());
 
         LogOnceLogger.LOGGER.deprecated("test.property", "new.test.property");
-        Assert.assertEquals(HANDLER.size(), 1, "Only one message should have been logged");
+        Assert.assertEquals("Only one message should have been logged", 1, HANDLER.size());
 
         final Method method = LogOnceTest.class.getMethod("logOnce");
         LogOnceLogger.LOGGER.deprecated(method);
         LogOnceLogger.LOGGER.deprecated(method);
-        Assert.assertEquals(HANDLER.size(), 3, "The message should have been logged twice");
+        Assert.assertEquals("The message should have been logged three times", 3, HANDLER.size());
     }
 
     @Test
     public void newLogger() throws Exception {
         final LogOnceLogger logger = Logger.getMessageLogger(LogOnceLogger.class, CATEGORY);
         logger.deprecated("test.property");
-        Assert.assertEquals(HANDLER.size(), 0, "No messages should have been logged");
+        Assert.assertEquals("No messages should have been logged", 0, HANDLER.size());
 
         logger.deprecated("test.property", "new.test.property");
-        Assert.assertEquals(HANDLER.size(), 0, "No messages should have been logged");
+        Assert.assertEquals("No messages should have been logged", 0, HANDLER.size());
 
     }
 
@@ -74,17 +77,17 @@ public class LogOnceTest extends AbstractLoggerTest {
         final List<String> listCache = Arrays.asList("item1", "item2", "item3");
         LogOnceLogger.LOGGER.cacheSizeChanged(listCache);
         LogOnceLogger.LOGGER.cacheSizeChanged(listCache);
-        Assert.assertEquals(HANDLER.size(), 1, "Only one message should have been logged");
+        Assert.assertEquals("Only one message should have been logged", 1, HANDLER.size());
 
         final Map<String, Object> mapCache = new HashMap<>();
         for (int i = 0; i < 5; i++) {
             mapCache.put("item" + i, "value " + i);
         }
         LogOnceLogger.LOGGER.cacheSizeChanged(mapCache);
-        Assert.assertEquals(HANDLER.size(), 1, "Only one message should have been logged");
+        Assert.assertEquals("Only one message should have been logged", 1, HANDLER.size());
 
         LogOnceLogger.LOGGER.cacheSizeChanged("item1", "item2", "item3", "item4");
         LogOnceLogger.LOGGER.cacheSizeChanged("item1", "item2", "item3", "item4", "item5", "item6");
-        Assert.assertEquals(HANDLER.size(), 3, "The message should have been logged twice");
+        Assert.assertEquals("The message should have been logged twice", 3, HANDLER.size());
     }
 }

--- a/processor/src/test/java/org/jboss/logging/processor/generated/LoggerVerificationTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/LoggerVerificationTest.java
@@ -33,9 +33,9 @@ import java.util.Properties;
 
 import org.jboss.logging.Logger;
 import org.jboss.logging.processor.generated.DefaultLogger.CustomFormatter;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -44,7 +44,7 @@ public class LoggerVerificationTest extends AbstractLoggerTest {
     private static final String NAME = System.getProperty("user.name");
     private static final String FILE_NAME_FORMAT = "DefaultLogger.i18n%s.properties";
 
-    @AfterMethod
+    @After
     public void clearHandler() {
         HANDLER.close();
     }
@@ -64,7 +64,7 @@ public class LoggerVerificationTest extends AbstractLoggerTest {
         logger.invalidSelection("A", "B", "C", "D");
 
         final Properties properties = findFile(String.format(FILE_NAME_FORMAT, ""));
-        Assert.assertEquals(properties.size(), HANDLER.size());
+        Assert.assertEquals(HANDLER.size(), properties.size());
         compare("hello", properties, NAME);
         compare("howAreYou", properties, NAME);
         compare("noFormat", properties);
@@ -80,7 +80,7 @@ public class LoggerVerificationTest extends AbstractLoggerTest {
         logger.hello(NAME);
         logger.howAreYou(NAME);
         final Properties properties = findFile(String.format(FILE_NAME_FORMAT, "_de"));
-        Assert.assertEquals(properties.size(), HANDLER.size());
+        Assert.assertEquals(HANDLER.size(), properties.size());
         compare("hello", properties, NAME);
         compare("howAreYou", properties, NAME);
     }
@@ -91,7 +91,7 @@ public class LoggerVerificationTest extends AbstractLoggerTest {
         logger.hello(NAME);
         logger.howAreYou(NAME);
         final Properties properties = findFile(String.format(FILE_NAME_FORMAT, "_fr"));
-        Assert.assertEquals(properties.size(), HANDLER.size());
+        Assert.assertEquals(HANDLER.size(), properties.size());
         compare("hello", properties, NAME);
         compare("howAreYou", properties, NAME);
     }
@@ -102,7 +102,7 @@ public class LoggerVerificationTest extends AbstractLoggerTest {
         logger.hello(NAME);
         logger.howAreYou(NAME);
         final Properties properties = findFile(String.format(FILE_NAME_FORMAT, "_es"));
-        Assert.assertEquals(properties.size(), HANDLER.size());
+        Assert.assertEquals(HANDLER.size(), properties.size());
         compare("hello", properties, NAME);
         compare("howAreYou", properties, NAME);
     }
@@ -113,7 +113,7 @@ public class LoggerVerificationTest extends AbstractLoggerTest {
         logger.hello(NAME);
         logger.howAreYou(NAME);
         final Properties properties = findFile(String.format(FILE_NAME_FORMAT, "_ja"));
-        Assert.assertEquals(properties.size(), HANDLER.size());
+        Assert.assertEquals(HANDLER.size(), properties.size());
         compare("hello", properties, NAME);
         compare("howAreYou", properties, NAME);
     }
@@ -148,7 +148,7 @@ public class LoggerVerificationTest extends AbstractLoggerTest {
     private void compare(final String key, final Properties properties, final Object... params) throws InterruptedException {
         final String expectedMessage = getFormattedProperty(key, properties, params);
         final String loggedMessage = HANDLER.getMessage().replaceAll(LOGGER_ID_PATTERN, "");
-        Assert.assertEquals(loggedMessage, expectedMessage);
+        Assert.assertEquals(expectedMessage, loggedMessage);
     }
 
     private String getFormattedProperty(final String key, final Properties properties, final Object... params) {

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MessagesTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MessagesTest.java
@@ -25,14 +25,13 @@ package org.jboss.logging.processor.generated;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Arrays;
-import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import org.jboss.logging.processor.generated.ValidMessages.CustomException;
 import org.jboss.logging.processor.generated.ValidMessages.LoggingException;
 import org.jboss.logging.processor.generated.ValidMessages.StringOnlyException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -43,26 +42,26 @@ public class MessagesTest {
 
     @Test
     public void testFormats() {
-        Assert.assertEquals(ValidMessages.MESSAGES.testWithNewLine(), FORMATTED_TEST_MSG);
-        Assert.assertEquals(ValidMessages.MESSAGES.noFormat(), ValidMessages.TEST_MSG);
-        Assert.assertEquals(ValidMessages.MESSAGES.noFormatException(new IllegalArgumentException()).getLocalizedMessage(), ValidMessages.TEST_MSG);
+        Assert.assertEquals(FORMATTED_TEST_MSG, ValidMessages.MESSAGES.testWithNewLine());
+        Assert.assertEquals(ValidMessages.TEST_MSG, ValidMessages.MESSAGES.noFormat());
+        Assert.assertEquals(ValidMessages.TEST_MSG, ValidMessages.MESSAGES.noFormatException(new IllegalArgumentException()).getLocalizedMessage());
 
         final int value = 10;
-        Assert.assertEquals(ValidMessages.MESSAGES.fieldMessage(value).value, value);
-        Assert.assertEquals(ValidMessages.MESSAGES.paramMessage(value).value, value);
-        Assert.assertEquals(ValidMessages.MESSAGES.propertyMessage(value).value, value);
+        Assert.assertEquals(value, ValidMessages.MESSAGES.fieldMessage(value).value);
+        Assert.assertEquals(value, ValidMessages.MESSAGES.paramMessage(value).value);
+        Assert.assertEquals(value, ValidMessages.MESSAGES.propertyMessage(value).value);
 
         final StringOnlyException e = ValidMessages.MESSAGES.stringOnlyException(new RuntimeException());
-        Assert.assertEquals(e.getMessage(), FORMATTED_TEST_MSG);
+        Assert.assertEquals(FORMATTED_TEST_MSG, e.getMessage());
         Assert.assertNotNull(e.getCause());
 
-        Assert.assertTrue(ValidMessages.MESSAGES.invalidCredentials() instanceof IllegalArgumentException, "Incorrect type constructed");
+        Assert.assertTrue("Incorrect type constructed", ValidMessages.MESSAGES.invalidCredentials() instanceof IllegalArgumentException);
 
         final String arg1 = "value-1";
         final String arg2 = "value-2";
         final String messageFormatMessage = MessageFormat.format(ValidMessages.TEST_MESSAGE_FORMAT, arg1, arg2);
-        Assert.assertEquals(ValidMessages.MESSAGES.testMessageFormat(arg1, arg2), messageFormatMessage);
-        Assert.assertEquals(ValidMessages.MESSAGES.testMessageFormatException(arg1, arg2).getMessage(), messageFormatMessage);
+        Assert.assertEquals(messageFormatMessage, ValidMessages.MESSAGES.testMessageFormat(arg1, arg2));
+        Assert.assertEquals(messageFormatMessage, ValidMessages.MESSAGES.testMessageFormatException(arg1, arg2).getMessage());
     }
 
     @Test
@@ -100,42 +99,42 @@ public class MessagesTest {
 
     @Test
     public void testPropertyConstants() {
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.booleanProperty().value, true);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.byteProperty().value, "x".getBytes()[0]);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.charProperty().value, MethodMessageConstants.testChar);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.classProperty().value, MethodMessageConstants.ValueType.class);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.douleProperty().value, Double.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.floatProperty().value, Float.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.intProperty().value, Integer.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.longProperty().value, Long.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.shortProperty().value, Short.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.stringProperty().value, MethodMessageConstants.stringTest);
+        Assert.assertEquals(true, MethodMessageConstants.MESSAGES.booleanProperty().value);
+        Assert.assertEquals("x".getBytes()[0], MethodMessageConstants.MESSAGES.byteProperty().value);
+        Assert.assertEquals(MethodMessageConstants.testChar, MethodMessageConstants.MESSAGES.charProperty().value);
+        Assert.assertEquals(MethodMessageConstants.ValueType.class, MethodMessageConstants.MESSAGES.classProperty().value);
+        Assert.assertEquals(Double.MAX_VALUE, MethodMessageConstants.MESSAGES.douleProperty().value, 0);
+        Assert.assertEquals(Float.MAX_VALUE, MethodMessageConstants.MESSAGES.floatProperty().value, 0);
+        Assert.assertEquals(Integer.MAX_VALUE, MethodMessageConstants.MESSAGES.intProperty().value);
+        Assert.assertEquals(Long.MAX_VALUE, MethodMessageConstants.MESSAGES.longProperty().value);
+        Assert.assertEquals(Short.MAX_VALUE, MethodMessageConstants.MESSAGES.shortProperty().value);
+        Assert.assertEquals(MethodMessageConstants.stringTest, MethodMessageConstants.MESSAGES.stringProperty().value);
         MethodMessageConstants.TypeException exception = MethodMessageConstants.MESSAGES.multiProperty();
-        Assert.assertEquals(exception.type, String.class);
-        Assert.assertEquals(exception.value, MethodMessageConstants.stringTest);
+        Assert.assertEquals(String.class, exception.type);
+        Assert.assertEquals(MethodMessageConstants.stringTest, exception.value);
         exception = MethodMessageConstants.MESSAGES.repeatableProperty();
-        Assert.assertEquals(exception.type, String.class);
-        Assert.assertEquals(exception.value, MethodMessageConstants.stringTest);
+        Assert.assertEquals(String.class, exception.type);
+        Assert.assertEquals(MethodMessageConstants.stringTest, exception.value);
     }
 
     @Test
     public void testFieldConstants() {
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.booleanField().value, true);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.byteField().value, "x".getBytes()[0]);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.charField().value, MethodMessageConstants.testChar);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.classField().value, MethodMessageConstants.ValueType.class);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.douleField().value, Double.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.floatField().value, Float.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.intField().value, Integer.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.longField().value, Long.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.shortField().value, Short.MAX_VALUE);
-        Assert.assertEquals(MethodMessageConstants.MESSAGES.stringField().value, MethodMessageConstants.stringTest);
+        Assert.assertEquals(true, MethodMessageConstants.MESSAGES.booleanField().value);
+        Assert.assertEquals("x".getBytes()[0], MethodMessageConstants.MESSAGES.byteField().value);
+        Assert.assertEquals(MethodMessageConstants.testChar, MethodMessageConstants.MESSAGES.charField().value);
+        Assert.assertEquals(MethodMessageConstants.ValueType.class, MethodMessageConstants.MESSAGES.classField().value);
+        Assert.assertEquals(Double.MAX_VALUE, MethodMessageConstants.MESSAGES.douleField().value, 0);
+        Assert.assertEquals(Float.MAX_VALUE, MethodMessageConstants.MESSAGES.floatField().value, 0);
+        Assert.assertEquals(Integer.MAX_VALUE, MethodMessageConstants.MESSAGES.intField().value);
+        Assert.assertEquals(Long.MAX_VALUE, MethodMessageConstants.MESSAGES.longField().value);
+        Assert.assertEquals(Short.MAX_VALUE, MethodMessageConstants.MESSAGES.shortField().value);
+        Assert.assertEquals(MethodMessageConstants.stringTest, MethodMessageConstants.MESSAGES.stringField().value);
         MethodMessageConstants.TypeException exception = MethodMessageConstants.MESSAGES.multiField();
-        Assert.assertEquals(exception.type, String.class);
-        Assert.assertEquals(exception.value, MethodMessageConstants.stringTest);
+        Assert.assertEquals(String.class, exception.type);
+        Assert.assertEquals(MethodMessageConstants.stringTest, exception.value);
         exception = MethodMessageConstants.MESSAGES.repeatableField();
-        Assert.assertEquals(exception.type, String.class);
-        Assert.assertEquals(exception.value, MethodMessageConstants.stringTest);
+        Assert.assertEquals(String.class, exception.type);
+        Assert.assertEquals(MethodMessageConstants.stringTest, exception.value);
     }
 
     @Test
@@ -143,85 +142,85 @@ public class MessagesTest {
         Supplier<RuntimeException> runtimeExceptionSupplier = ValidMessages.MESSAGES.testSupplierRuntimeException();
         Assert.assertNotNull(runtimeExceptionSupplier);
         RuntimeException runtimeException = runtimeExceptionSupplier.get();
-        Assert.assertEquals(runtimeException.getMessage(), FORMATTED_TEST_MSG);
-        Assert.assertEquals(runtimeException.getClass(), RuntimeException.class);
+        Assert.assertEquals(FORMATTED_TEST_MSG, runtimeException.getMessage());
+        Assert.assertEquals(RuntimeException.class, runtimeException.getClass());
 
-        Assert.assertEquals(FORMATTED_TEST_MSG, ValidMessages.MESSAGES.testSupplierString().get());
+        Assert.assertEquals(ValidMessages.MESSAGES.testSupplierString().get(), FORMATTED_TEST_MSG);
 
         runtimeExceptionSupplier = ValidMessages.MESSAGES.invalidCredentialsSupplier();
         Assert.assertNotNull(runtimeExceptionSupplier);
         runtimeException = runtimeExceptionSupplier.get();
-        Assert.assertEquals(runtimeException.getClass(), IllegalArgumentException.class);
+        Assert.assertEquals(IllegalArgumentException.class, runtimeException.getClass());
 
         // Test suppliers with fields/properties
         int value = 5;
         Supplier<CustomException> customExceptionSupplier = ValidMessages.MESSAGES.fieldMessageSupplier(value);
         Assert.assertNotNull(customExceptionSupplier);
         CustomException customException = customExceptionSupplier.get();
-        Assert.assertEquals(customException.getMessage(), FORMATTED_TEST_MSG);
-        Assert.assertEquals(customException.getClass(), CustomException.class);
-        Assert.assertEquals(customException.value, value);
+        Assert.assertEquals(FORMATTED_TEST_MSG, customException.getMessage());
+        Assert.assertEquals(CustomException.class, customException.getClass());
+        Assert.assertEquals(value, customException.value);
 
         value = 20;
         customExceptionSupplier = ValidMessages.MESSAGES.propertyMessageSupplier(value);
         Assert.assertNotNull(customExceptionSupplier);
         customException = customExceptionSupplier.get();
-        Assert.assertEquals(customException.getMessage(), FORMATTED_TEST_MSG);
-        Assert.assertEquals(customException.getClass(), CustomException.class);
-        Assert.assertEquals(customException.value, value);
+        Assert.assertEquals(FORMATTED_TEST_MSG, customException.getMessage());
+        Assert.assertEquals(CustomException.class, customException.getClass());
+        Assert.assertEquals(value, customException.value);
 
     }
 
     @Test
     public void testFunctionProducerMessages() throws Exception {
         RuntimeException runtimeException = ValidMessages.MESSAGES.operationFailed(IllegalArgumentException::new, "start");
-        Assert.assertEquals(runtimeException.getClass(), IllegalArgumentException.class);
-        Assert.assertEquals(runtimeException.getMessage(), String.format(ValidMessages.TEST_OP_FAILED_MSG, "start"));
+        Assert.assertEquals(IllegalArgumentException.class, runtimeException.getClass());
+        Assert.assertEquals(String.format(ValidMessages.TEST_OP_FAILED_MSG, "start"), runtimeException.getMessage());
 
         IOException ioException = ValidMessages.MESSAGES.operationFailed(IOException::new, "query");
-        Assert.assertEquals(ioException.getMessage(), String.format(ValidMessages.TEST_OP_FAILED_MSG, "query"));
+        Assert.assertEquals(String.format(ValidMessages.TEST_OP_FAILED_MSG, "query"), ioException.getMessage());
 
         final Supplier<IllegalStateException> supplier = ValidMessages.MESSAGES.supplierFunction(IllegalStateException::new);
         runtimeException = supplier.get();
-        Assert.assertEquals(runtimeException.getClass(), IllegalStateException.class);
-        Assert.assertEquals(runtimeException.getMessage(), FORMATTED_TEST_MSG);
+        Assert.assertEquals(IllegalStateException.class, runtimeException.getClass());
+        Assert.assertEquals(FORMATTED_TEST_MSG, runtimeException.getMessage());
 
         // Test functions with fields/properties
         int value = 5;
         CustomException customException = ValidMessages.MESSAGES.fieldMessageFunction(CustomException::new, value);
-        Assert.assertEquals(customException.getMessage(), FORMATTED_TEST_MSG);
-        Assert.assertEquals(customException.getClass(), CustomException.class);
+        Assert.assertEquals(FORMATTED_TEST_MSG, customException.getMessage());
+        Assert.assertEquals(CustomException.class, customException.getClass());
         Assert.assertEquals(customException.value, value);
 
         value = 20;
         customException = ValidMessages.MESSAGES.propertyMessageFunction(CustomException::new, value);
-        Assert.assertEquals(customException.getMessage(), FORMATTED_TEST_MSG);
-        Assert.assertEquals(customException.getClass(), CustomException.class);
-        Assert.assertEquals(customException.value, value);
+        Assert.assertEquals(FORMATTED_TEST_MSG, customException.getMessage());
+        Assert.assertEquals(CustomException.class, customException.getClass());
+        Assert.assertEquals(value, customException.value);
     }
 
     @Test
     public void testBiFunctionProducerMessages() throws Exception {
         final RuntimeException cause = new RuntimeException("This is the cause");
         RuntimeException runtimeException = ValidMessages.MESSAGES.operationFailed(IllegalArgumentException::new, cause, "start");
-        Assert.assertEquals(runtimeException.getClass(), IllegalArgumentException.class);
-        Assert.assertEquals(runtimeException.getMessage(), String.format(ValidMessages.TEST_OP_FAILED_MSG, "start"));
-        Assert.assertEquals(runtimeException.getCause(), cause);
+        Assert.assertEquals(IllegalArgumentException.class, runtimeException.getClass());
+        Assert.assertEquals(String.format(ValidMessages.TEST_OP_FAILED_MSG, "start"), runtimeException.getMessage());
+        Assert.assertEquals(cause, runtimeException.getCause());
 
         runtimeException = ValidMessages.MESSAGES.throwableStringBiFunction(LoggingException::new, cause);
-        Assert.assertEquals(runtimeException.getClass(), LoggingException.class);
-        Assert.assertEquals(runtimeException.getCause(), cause);
+        Assert.assertEquals(LoggingException.class, runtimeException.getClass());
+        Assert.assertEquals(cause, runtimeException.getCause());
 
         final Supplier<RuntimeException> supplier = ValidMessages.MESSAGES.throwableStringBiFunctionSupplier(IllegalArgumentException::new, cause);
         runtimeException = supplier.get();
-        Assert.assertEquals(runtimeException.getClass(), IllegalArgumentException.class);
-        Assert.assertEquals(runtimeException.getMessage(), FORMATTED_TEST_MSG);
-        Assert.assertEquals(runtimeException.getCause(), cause);
+        Assert.assertEquals(IllegalArgumentException.class, runtimeException.getClass());
+        Assert.assertEquals(FORMATTED_TEST_MSG, runtimeException.getMessage());
+        Assert.assertEquals(cause, runtimeException.getCause());
 
     }
 
     private <T> void compare(final T[] a1, final T[] a2) {
-        Assert.assertTrue(equalsIgnoreOrder(a1, a2), String.format("Expected: %s%n Actual: %s", Arrays.toString(a1), Arrays.toString(a2)));
+        Assert.assertTrue(String.format("Expected: %s%n Actual: %s", Arrays.toString(a1), Arrays.toString(a2)), equalsIgnoreOrder(a1, a2));
     }
 
     private <T> boolean equalsIgnoreOrder(final T[] a1, final T[] a2) {

--- a/processor/src/test/java/org/jboss/logging/processor/generated/ThrowableSignatureTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/ThrowableSignatureTest.java
@@ -25,8 +25,8 @@ package org.jboss.logging.processor.generated;
 import org.jboss.logging.processor.generated.SignatureMessages.InvalidTextException;
 import org.jboss.logging.processor.generated.SignatureMessages.RedirectException;
 import org.jboss.logging.processor.generated.SignatureMessages.TestException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -41,24 +41,24 @@ public class ThrowableSignatureTest {
         final int code = 307;
         final String location = "foo";
         RedirectException redirectExpected = new RedirectException(formattedMessage, code, location);
-        Assert.assertEquals(SignatureMessages.MESSAGES.redirect(code, location), redirectExpected);
+        Assert.assertEquals(redirectExpected, SignatureMessages.MESSAGES.redirect(code, location));
         redirectExpected = new RedirectException(formattedMessage, location);
         redirectExpected.initCause(cause);
-        Assert.assertEquals(SignatureMessages.MESSAGES.redirect(cause, location), redirectExpected);
+        Assert.assertEquals(redirectExpected, SignatureMessages.MESSAGES.redirect(cause, location));
         redirectExpected = new RedirectException(formattedMessage, cause, code, location);
-        Assert.assertEquals(SignatureMessages.MESSAGES.redirect(cause, code, location), redirectExpected);
+        Assert.assertEquals(redirectExpected, SignatureMessages.MESSAGES.redirect(cause, code, location));
 
         TestException testExpected = new TestException(formattedMessage);
-        Assert.assertEquals(SignatureMessages.MESSAGES.test(), testExpected);
+        Assert.assertEquals(testExpected, SignatureMessages.MESSAGES.test());
         testExpected = new TestException(formattedMessage, cause);
-        Assert.assertEquals(SignatureMessages.MESSAGES.test(cause), testExpected);
+        Assert.assertEquals(testExpected, SignatureMessages.MESSAGES.test(cause));
 
         final String invalidText = "invalid";
         InvalidTextException invalidTextExpected = new InvalidTextException(formattedMessage, invalidText);
-        Assert.assertEquals(SignatureMessages.MESSAGES.invalidText(invalidText), invalidTextExpected);
+        Assert.assertEquals(invalidTextExpected, SignatureMessages.MESSAGES.invalidText(invalidText));
         invalidTextExpected = new InvalidTextException(formattedMessage, cause, invalidText);
-        Assert.assertEquals(SignatureMessages.MESSAGES.invalidText(cause, invalidText), invalidTextExpected);
+        Assert.assertEquals(invalidTextExpected, SignatureMessages.MESSAGES.invalidText(cause, invalidText));
         invalidTextExpected = new InvalidTextException(3, cause, invalidText, formattedMessage);
-        Assert.assertEquals(SignatureMessages.MESSAGES.invalidText(3, cause, invalidText), invalidTextExpected);
+        Assert.assertEquals(invalidTextExpected, SignatureMessages.MESSAGES.invalidText(3, cause, invalidText));
     }
 }

--- a/processor/src/test/java/org/jboss/logging/processor/generated/TransformTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/TransformTest.java
@@ -27,8 +27,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -41,60 +41,60 @@ public class TransformTest extends AbstractLoggerTest {
         // Log strings
         final String s = "This is a test string";
         TransformLogger.LOGGER.logClassHashCode(s);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, s.getClass().hashCode()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, s.getClass().hashCode()), HANDLER.getMessage());
         TransformLogger.LOGGER.logClassIdentityHashCode(s);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(s.getClass())));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(s.getClass())), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectClass(s);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.GET_CLASS_MSG, s.getClass()));
+        Assert.assertEquals(String.format(TransformLogger.GET_CLASS_MSG, s.getClass()), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectHashCode(s);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, s.hashCode()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, s.hashCode()), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectIdentityHashCode(s);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(s)));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(s)), HANDLER.getMessage());
         TransformLogger.LOGGER.logSize(s);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.SIZE_MSG, s.length()));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, s.length()), HANDLER.getMessage());
 
         // Log collections
         final Collection<String> c = Arrays.asList("test");
         TransformLogger.LOGGER.logClassHashCode(c);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, c.getClass().hashCode()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, c.getClass().hashCode()), HANDLER.getMessage());
         TransformLogger.LOGGER.logClassIdentityHashCode(c);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(c.getClass())));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(c.getClass())), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectHashCode(c);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, c.hashCode()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, c.hashCode()), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectIdentityHashCode(c);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(c)));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(c)), HANDLER.getMessage());
         TransformLogger.LOGGER.logSize(c);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.SIZE_MSG, c.size()));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, c.size()), HANDLER.getMessage());
 
         // Log an array
         final Object[] array = {"test1", "test2", "test3"};
         TransformLogger.LOGGER.logClassHashCode(array);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, array.getClass().hashCode()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, array.getClass().hashCode()), HANDLER.getMessage());
         TransformLogger.LOGGER.logClassIdentityHashCode(array);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(array.getClass())));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(array.getClass())), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectClass(array);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.GET_CLASS_MSG, array.getClass()));
+        Assert.assertEquals(String.format(TransformLogger.GET_CLASS_MSG, array.getClass()), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectHashCode(array);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, Arrays.hashCode(array)));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, Arrays.hashCode(array)), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectIdentityHashCode(array);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(array)));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(array)), HANDLER.getMessage());
         TransformLogger.LOGGER.logSize(array);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.SIZE_MSG, array.length));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, array.length), HANDLER.getMessage());
 
         // Log vararg array
         final String[] sArray = {"test1", "test2", "test3"};
         TransformLogger.LOGGER.logClassHashCode(sArray);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, sArray.getClass().hashCode()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, sArray.getClass().hashCode()), HANDLER.getMessage());
         TransformLogger.LOGGER.logClassIdentityHashCode(sArray);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(sArray.getClass())));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(sArray.getClass())), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectClass(sArray);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.GET_CLASS_MSG, sArray.getClass()));
+        Assert.assertEquals(String.format(TransformLogger.GET_CLASS_MSG, sArray.getClass()), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectHashCode(sArray);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, Arrays.hashCode(sArray)));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, Arrays.hashCode(sArray)), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectIdentityHashCode(sArray);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(sArray)));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(sArray)), HANDLER.getMessage());
         TransformLogger.LOGGER.logSize(sArray);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.SIZE_MSG, sArray.length));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, sArray.length), HANDLER.getMessage());
 
         // Log a map
         final Map<String, String> map = new HashMap<>();
@@ -102,64 +102,64 @@ public class TransformTest extends AbstractLoggerTest {
             map.put("key" + i, "value" + i);
         }
         TransformLogger.LOGGER.logClassHashCode(map);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, map.getClass().hashCode()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, map.getClass().hashCode()), HANDLER.getMessage());
         TransformLogger.LOGGER.logClassIdentityHashCode(map);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(map.getClass())));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(map.getClass())), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectHashCode(map);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.HASH_CODE_MSG, map.hashCode()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, map.hashCode()), HANDLER.getMessage());
         TransformLogger.LOGGER.logObjectIdentityHashCode(map);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(map)));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(map)), HANDLER.getMessage());
         TransformLogger.LOGGER.logSize(map);
-        Assert.assertEquals(HANDLER.getMessage(), String.format(TransformLogger.SIZE_MSG, map.size()));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, map.size()), HANDLER.getMessage());
     }
 
     @Test
     public void testMessage() throws Exception {
         // Log strings
         final String s = "This is a test string";
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassHashCode(s), String.format(TransformLogger.HASH_CODE_MSG, s.getClass().hashCode()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassIdentityHashCode(s), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(s.getClass())));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectClass(s), String.format(TransformLogger.GET_CLASS_MSG, s.getClass()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectHashCode(s), String.format(TransformLogger.HASH_CODE_MSG, s.hashCode()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectIdentityHashCode(s), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(s)));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgSize(s), String.format(TransformLogger.SIZE_MSG, s.length()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, s.getClass().hashCode()), TransformMessages.MESSAGES.msgClassHashCode(s));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(s.getClass())), TransformMessages.MESSAGES.msgClassIdentityHashCode(s));
+        Assert.assertEquals(String.format(TransformLogger.GET_CLASS_MSG, s.getClass()), TransformMessages.MESSAGES.msgObjectClass(s));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, s.hashCode()), TransformMessages.MESSAGES.msgObjectHashCode(s));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(s)), TransformMessages.MESSAGES.msgObjectIdentityHashCode(s));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, s.length()), TransformMessages.MESSAGES.msgSize(s));
 
         // Log collections
         final Collection<String> c = Arrays.asList("test");
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassHashCode(c), String.format(TransformLogger.HASH_CODE_MSG, c.getClass().hashCode()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassIdentityHashCode(c), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(c.getClass())));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectHashCode(c), String.format(TransformLogger.HASH_CODE_MSG, c.hashCode()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectIdentityHashCode(c), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(c)));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgSize(c), String.format(TransformLogger.SIZE_MSG, c.size()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, c.getClass().hashCode()), TransformMessages.MESSAGES.msgClassHashCode(c));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(c.getClass())), TransformMessages.MESSAGES.msgClassIdentityHashCode(c));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, c.hashCode()), TransformMessages.MESSAGES.msgObjectHashCode(c));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(c)), TransformMessages.MESSAGES.msgObjectIdentityHashCode(c));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, c.size()), TransformMessages.MESSAGES.msgSize(c));
 
         // Log an array
         final Object[] array = {"test1", "test2", "test3"};
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassHashCode(array), String.format(TransformLogger.HASH_CODE_MSG, array.getClass().hashCode()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassIdentityHashCode(array), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(array.getClass())));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectClass(array), String.format(TransformLogger.GET_CLASS_MSG, array.getClass()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectHashCode(array), String.format(TransformLogger.HASH_CODE_MSG, Arrays.hashCode(array)));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectIdentityHashCode(array), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(array)));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgSize(array), String.format(TransformLogger.SIZE_MSG, array.length));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, array.getClass().hashCode()), TransformMessages.MESSAGES.msgClassHashCode(array));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(array.getClass())), TransformMessages.MESSAGES.msgClassIdentityHashCode(array));
+        Assert.assertEquals(String.format(TransformLogger.GET_CLASS_MSG, array.getClass()), TransformMessages.MESSAGES.msgObjectClass(array));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, Arrays.hashCode(array)), TransformMessages.MESSAGES.msgObjectHashCode(array));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(array)), TransformMessages.MESSAGES.msgObjectIdentityHashCode(array));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, array.length), TransformMessages.MESSAGES.msgSize(array));
 
         // Log vararg array
         final String[] sArray = {"test1", "test2", "test3"};
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassHashCode(sArray), String.format(TransformLogger.HASH_CODE_MSG, sArray.getClass().hashCode()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassIdentityHashCode(sArray), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(sArray.getClass())));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectClass(sArray), String.format(TransformLogger.GET_CLASS_MSG, sArray.getClass()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectHashCode(sArray), String.format(TransformLogger.HASH_CODE_MSG, Arrays.hashCode(sArray)));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectIdentityHashCode(sArray), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(sArray)));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgSize(sArray), String.format(TransformLogger.SIZE_MSG, sArray.length));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, sArray.getClass().hashCode()), TransformMessages.MESSAGES.msgClassHashCode(sArray));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(sArray.getClass())), TransformMessages.MESSAGES.msgClassIdentityHashCode(sArray));
+        Assert.assertEquals(String.format(TransformLogger.GET_CLASS_MSG, sArray.getClass()), TransformMessages.MESSAGES.msgObjectClass(sArray));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, Arrays.hashCode(sArray)), TransformMessages.MESSAGES.msgObjectHashCode(sArray));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(sArray)), TransformMessages.MESSAGES.msgObjectIdentityHashCode(sArray));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, sArray.length), TransformMessages.MESSAGES.msgSize(sArray));
 
         // Log a map
         final Map<String, String> map = new HashMap<>();
         for (int i = 0; i < 10; i++) {
             map.put("key" + i, "value" + i);
         }
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassHashCode(map), String.format(TransformLogger.HASH_CODE_MSG, map.getClass().hashCode()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgClassIdentityHashCode(map), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(map.getClass())));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectHashCode(map), String.format(TransformLogger.HASH_CODE_MSG, map.hashCode()));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgObjectIdentityHashCode(map), String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(map)));
-        Assert.assertEquals(TransformMessages.MESSAGES.msgSize(map), String.format(TransformLogger.SIZE_MSG, map.size()));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, map.getClass().hashCode()), TransformMessages.MESSAGES.msgClassHashCode(map));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(map.getClass())), TransformMessages.MESSAGES.msgClassIdentityHashCode(map));
+        Assert.assertEquals(String.format(TransformLogger.HASH_CODE_MSG, map.hashCode()), TransformMessages.MESSAGES.msgObjectHashCode(map));
+        Assert.assertEquals(String.format(TransformLogger.IDENTITY_HASH_CODE_MSG, System.identityHashCode(map)), TransformMessages.MESSAGES.msgObjectIdentityHashCode(map));
+        Assert.assertEquals(String.format(TransformLogger.SIZE_MSG, map.size()), TransformMessages.MESSAGES.msgSize(map));
     }
 
     @Test
@@ -170,8 +170,8 @@ public class TransformTest extends AbstractLoggerTest {
         final String msg2 = "Test message 2";
         String expected = String.format(TransformLogger.POS_MSG_1, msg2.length(), msg1.hashCode(), System.identityHashCode(msg1));
         TransformLogger.LOGGER.posTest1(msg1, msg2);
-        Assert.assertEquals(HANDLER.getMessage(), expected);
-        Assert.assertEquals(TransformMessages.MESSAGES.posTest1(msg1, msg2), expected);
+        Assert.assertEquals(expected, HANDLER.getMessage());
+        Assert.assertEquals(expected, TransformMessages.MESSAGES.posTest1(msg1, msg2));
 
         final Object obj = "Test";
         final String msg = "This is a test message";
@@ -179,7 +179,7 @@ public class TransformTest extends AbstractLoggerTest {
         final String s2 = "s2";
         expected = String.format(TransformLogger.POS_MSG_2, msg.length(), s1, s2, obj.getClass());
         TransformLogger.LOGGER.posTest2(obj, msg, s1, s2);
-        Assert.assertEquals(HANDLER.getMessage(), expected);
-        Assert.assertEquals(TransformMessages.MESSAGES.posTest2(obj, msg, s1, s2), expected);
+        Assert.assertEquals(expected, HANDLER.getMessage());
+        Assert.assertEquals(expected, TransformMessages.MESSAGES.posTest2(obj, msg, s1, s2));
     }
 }

--- a/processor/src/test/java/org/jboss/logging/processor/report/ReportGenerationTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/report/ReportGenerationTest.java
@@ -39,9 +39,9 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.validation.SchemaFactory;
 
 import org.jboss.logging.processor.apt.report.ReportType;
-import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -63,13 +63,13 @@ public class ReportGenerationTest {
     public void testAsciidoc() throws Exception {
         final Collection<Path> paths = findFiles(ReportType.ASCIIDOC);
         // Just ensure they were generated
-        Assert.assertFalse(paths.isEmpty(), "No asciidoc files found");
+        Assert.assertFalse("No asciidoc files found", paths.isEmpty());
     }
 
     @Test
     public void testXml() throws Exception {
         final Collection<Path> paths = findFiles(ReportType.XML);
-        Assert.assertFalse(paths.isEmpty(), "No XML files found");
+        Assert.assertFalse("No XML files found", paths.isEmpty());
         final SAXParserFactory factory = SAXParserFactory.newInstance();
         factory.setNamespaceAware(true);
 

--- a/processor/src/test/java/org/jboss/logging/processor/util/VersionComparatorTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/util/VersionComparatorTest.java
@@ -22,8 +22,8 @@
 
 package org.jboss.logging.processor.util;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Date: 09.11.2011

--- a/processor/src/test/java/org/jboss/logging/processor/validation/MessageFormatValidatorTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/validation/MessageFormatValidatorTest.java
@@ -22,9 +22,10 @@
 
 package org.jboss.logging.processor.validation;
 
-import static org.testng.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 /**
  * Date: 14.06.2011
@@ -36,10 +37,10 @@ public class MessageFormatValidatorTest {
     @Test
     public void validFormats() {
         MessageFormatValidator validator = MessageFormatValidator.of("Message {} is valid.");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = MessageFormatValidator.of("Parameter {1} is not compatible with {2}.");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
     }
 
     @Test
@@ -51,12 +52,12 @@ public class MessageFormatValidatorTest {
     @Test
     public void validateParameterCount() {
         MessageFormatValidator validator = MessageFormatValidator.of("{}", "Test");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = MessageFormatValidator.of("{1} {0}", "Test", "Test2");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = MessageFormatValidator.of("{0} {0}", "Test");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
     }
 }

--- a/processor/src/test/java/org/jboss/logging/processor/validation/StringFormatValidatorTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/validation/StringFormatValidatorTest.java
@@ -22,12 +22,12 @@
 
 package org.jboss.logging.processor.validation;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
 
-import org.testng.annotations.Test;
+import org.junit.Test;
 
 /**
  * Date: 14.06.2011
@@ -48,7 +48,7 @@ public class StringFormatValidatorTest {
             }
         }
         StringFormatValidator validator = StringFormatValidator.of(sb.toString());
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         final String[] validFormats = {
                 "%1$s %1$s %1$s",
@@ -60,7 +60,7 @@ public class StringFormatValidatorTest {
         };
         for (String s : validFormats) {
             validator = StringFormatValidator.of(s);
-            assertTrue(validator.isValid(), validator.detailMessage());
+            assertTrue(validator.detailMessage(), validator.isValid());
         }
     }
 
@@ -73,10 +73,10 @@ public class StringFormatValidatorTest {
     @Test
     public void validateParameterCount() {
         StringFormatValidator validator = StringFormatValidator.of("%1$s %1$s %1$s", "Test");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.of("Duke's Birthday: %1$tm %1$te,%1$tY", new Date());
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.of("Duke's Birthday: %1$tm %<te,%<tY", new Date(), new Date());
         assertFalse(validator.isValid());
@@ -85,22 +85,22 @@ public class StringFormatValidatorTest {
     @Test
     public void validateParameterTypePerPosition() {
         StringFormatValidator validator = StringFormatValidator.of("%1$s %2$d %3$s", "Test", 10, "Again");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.of("%3$s %1$d %2$s", "Test", 42, "order");
-        assertFalse(validator.isValid(), validator.detailMessage());
+        assertFalse(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.of("%2$d %1$s", "Test", 42);
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.of("%3$s %1$d %3$s %2$tm", 42, new Date(), "Test");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.of("%2$d %<d %s", "Test", 42);
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.of("The error is %s, I repeat %1$s", "invalid");
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
     }
 
@@ -110,17 +110,17 @@ public class StringFormatValidatorTest {
         String positional = "Test param 2 %2$s new line %n param 1 %1$s%n";
         // If parameters are specified in the either one of the formats, the validation should pass
         StringFormatValidator validator = StringFormatValidator.withTranslation(nonPositional, positional);
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.withTranslation(positional, nonPositional);
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         nonPositional = "Test param 1 %s percent %% param 2 %s%%%n";
         positional = "Test param 2 %2$s percent %% param 1 %1$s%%%n";
         validator = StringFormatValidator.withTranslation(nonPositional, positional);
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
 
         validator = StringFormatValidator.withTranslation(positional, nonPositional);
-        assertTrue(validator.isValid(), validator.detailMessage());
+        assertTrue(validator.detailMessage(), validator.isValid());
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/LOGTOOL-125

Most JBoss projects use junit instead of testng. It can be a bit confusing when writing tests since assertions are ordered differently. Keeping the testing framework consistent is preferred.