### PR TITLE
[LOGTOOL-127] Allow system properties and environment variables to be…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,8 @@
 
 The JBoss logging tools are used to create internationalized log statements and exceptions.
 
-For user documentation see https://jboss-logging.github.io/jboss-logging-tools/
+For user documentation see https://jboss-logging.github.io/jboss-logging-tools/. For annotation JavaDoc's see
+https://jboss-logging.github.io/jboss-logging-tools/apidocs/.
 
 == Building
 

--- a/annotations/src/main/java/org/jboss/logging/annotations/BaseUrl.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/BaseUrl.java
@@ -30,8 +30,10 @@ import java.lang.annotation.Target;
  * Messages on reports can have a link to a {@linkplain ResolutionDoc resolution document}. This annotation can be used
  * to provide a base URL for these documents.
  * <p>
- * Expressions in the form of {@code ${system.property.key:default-value}} can be used for the value. The
- * {@code org.jboss.logging.tools.expressionProperties} processor argument is used to specify the path the properties
+ * Expressions in the form of {@code ${property.key:default-value}} can be used for the values. If the property key is
+ * prefixed with {@code sys.} a {@linkplain System#getProperty(String) system property} will be used. If the key is
+ * prefixed with {@code env.} an {@linkplain System#getenv(String) environment variable} will be used. In all other cases
+ * the {@code org.jboss.logging.tools.expressionProperties} processor argument is used to specify the path the properties
  * file which contains the values for the expressions.
  * </p>
  *

--- a/annotations/src/main/java/org/jboss/logging/annotations/Message.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Message.java
@@ -55,6 +55,13 @@ public @interface Message {
 
     /**
      * The default format string of this message.
+     * <p>
+     * Expressions in the form of {@code ${property.key:default-value}} can be used for the value. If the property key is
+     * prefixed with {@code sys.} a {@linkplain System#getProperty(String) system property} will be used. If the key is
+     * prefixed with {@code env.} an {@linkplain System#getenv(String) environment variable} will be used. In all other cases
+     * the {@code org.jboss.logging.tools.expressionProperties} processor argument is used to specify the path the properties
+     * file which contains the values for the expressions.
+     * </p>
      *
      * @return the format string
      */

--- a/annotations/src/main/java/org/jboss/logging/annotations/ResolutionDoc.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/ResolutionDoc.java
@@ -56,9 +56,12 @@ import java.lang.annotation.Target;
  * the resolution document.
  * </p>
  * <p>
- * Expressions in the form of {@code ${system.property.key:default-value}} can be used for the values with the exception
- * of the {@link #skip() skip} attribute. The {@code org.jboss.logging.tools.expressionProperties} processor argument is
- * used to specify the path the properties file which contains the values for the expressions.
+ * Expressions in the form of {@code ${property.key:default-value}} can be used for the values with the exception of the
+ * {@link #skip() skip} attribute. If the property key is prefixed with {@code sys.} a
+ * {@linkplain System#getProperty(String) system property} will be used. If the key is prefixed with {@code env.} an
+ * {@linkplain System#getenv(String) environment variable} will be used. In all other cases the
+ * {@code org.jboss.logging.tools.expressionProperties} processor argument is used to specify the path the properties
+ * file which contains the values for the expressions.
  * </p>
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>

--- a/docs/src/main/asciidoc/expressions.adoc
+++ b/docs/src/main/asciidoc/expressions.adoc
@@ -1,0 +1,7 @@
+
+NOTE: Expressions are in the form of `${key:defaultValue}`. If the key is prefixed with `sys.` a system property is
+used. If the key is prefixed with `env.` an environment variable is used. In all other cases the properties are resolved
+from the `org.jboss.logging.tools.expressionProperties` path. If the key is not found in the properties the default
+value will be used.
+
+IMPORTANT: Expressions are processed at compile time. The values will be hard-coded in the generated source files.

--- a/docs/src/main/asciidoc/message-bundle.adoc
+++ b/docs/src/main/asciidoc/message-bundle.adoc
@@ -1,7 +1,14 @@
 
 == Message Bundle Interfaces
 
-Message bundle interfaces provide a way to internationalize exceptions or strings. A message bundle interface is annotated with link:{javadocsdir}[`@MessageBundle`]. Each method in must be annotated with link:{javadocsdir}[`@Message`] which will be used to determine the String used for either the return type or the message for the exception being returned.
+Message bundle interfaces provide a way to internationalize exceptions or strings. A message bundle interface is
+annotated with link:{javadocsdir}[`@MessageBundle`]. Each method in must be annotated with link:{javadocsdir}[`@Message`]
+which will be used to determine the String used for either the return type or the message for the exception being
+returned.
+
+The value for a link:{javadocsdir}[`@Message`] may contain an expression.
+
+include::expressions.adoc[]
 
 The following constraints are placed on methods in a message bundle:
 

--- a/docs/src/main/asciidoc/message-logger.adoc
+++ b/docs/src/main/asciidoc/message-logger.adoc
@@ -1,7 +1,13 @@
 
 == Message Logger Interfaces
 
-Logger interfaces provide a way to internationalize log messages. A logger interface is an interface annotated with link:{javadocsdir}[`@MessageLogger`]. Each method in must be annotated with link:{javadocsdir}[`@Message`] which will be used to determine the message to be logged.
+Logger interfaces provide a way to internationalize log messages. A logger interface is an interface annotated with
+link:{javadocsdir}[`@MessageLogger`]. Each method in must be annotated with link:{javadocsdir}[`@Message`] which will
+be used to determine the message to be logged.
+
+The value for a link:{javadocsdir}[`@Message`] may contain an expression.
+
+include::expressions.adoc[]
 
 The following constraints are placed on methods in a message logger:
 

--- a/docs/src/main/asciidoc/processor-options.adoc
+++ b/docs/src/main/asciidoc/processor-options.adoc
@@ -16,6 +16,7 @@ You can pass options to an annotation processor with the `-A` compiler option. F
 
 NOTE: In Java 9 the `@javax.annotation.Generated` was moved to `@javax.annotation.processor.Generated`. The processor attempts to determine which annotation to use by attempting to find the `@javax.annotation.Generated` first. If it fails the `@javax.annotation.processor.Generated` is attempted. If neither can be found no annotation will be placed on the generated implementations.
 
+include::expressions.adoc[]
 
 === Translation Options
 

--- a/processor-tests/pom.xml
+++ b/processor-tests/pom.xml
@@ -98,6 +98,7 @@
                 <configuration>
                     <testExcludes>
                         <exclude>**/ExpressionMessagesTest.java</exclude>
+                        <exclude>**/ExpressionsTest.java</exclude>
                         <exclude>**/LegacyLogger.java</exclude>
                         <exclude>**/LegacyLoggerTest.java</exclude>
                         <exclude>**/LegacyMessages.java</exclude>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -142,11 +142,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <environmentVariables>
+                        <JBOSS_LOGGING_TEST_VAR>envValue</JBOSS_LOGGING_TEST_VAR>
+                    </environmentVariables>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <test.src.path>${project.build.testSourceDirectory}</test.src.path>
                         <test.generated.src.path>${project.build.directory}/generated-test-sources/test-annotations</test.generated.src.path>
                         <test.report.path>${test.report.path}</test.report.path>
+                        <test.property>sysValue</test.property>
+                        <expressionPropertiesPath>${expression.properties.path}</expressionPropertiesPath>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/processor/src/main/java/org/jboss/logging/processor/util/Expressions.java
+++ b/processor/src/main/java/org/jboss/logging/processor/util/Expressions.java
@@ -87,7 +87,14 @@ public class Expressions {
                         case '}':
                         case ',': {
                             final String name = expression.substring(nameStart, i).trim();
-                            final String val = props.getProperty(name);
+                            final String val;
+                            if (name.startsWith("env.")) {
+                                val = System.getenv(name.substring(4));
+                            } else if (name.startsWith("sys.")) {
+                                val = System.getProperty(name.substring(4));
+                            } else {
+                                val = props.getProperty(name);
+                            }
                             if (val != null) {
                                 builder.append(val);
                                 state = ch == '}' ? INITIAL : RESOLVED;

--- a/processor/src/test/java/org/jboss/logging/processor/util/ExpressionsTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/util/ExpressionsTest.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.logging.processor.util;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ExpressionsTest {
+
+    private static final Properties PROPERTIES = new Properties();
+
+    @BeforeClass
+    public static void configureProperties() throws IOException {
+        PROPERTIES.load(ExpressionsTest.class.getResourceAsStream("/expression.properties"));
+    }
+
+    @Test
+    public void testEnvironmentVariables() throws Exception {
+        Assert.assertEquals("envValue", Expressions.resolve(PROPERTIES, "${env.JBOSS_LOGGING_TEST_VAR}"));
+        Assert.assertEquals("defaultValue", Expressions.resolve(PROPERTIES, "${env.JBOSS_LOGGING_TEST_INVALID:defaultValue}"));
+    }
+
+    @Test
+    public void testSystemProperties() {
+        Assert.assertEquals(System.getProperty("user.home"), Expressions.resolve(PROPERTIES, "${sys.user.home}"));
+        Assert.assertEquals("sysValue", Expressions.resolve(PROPERTIES, "${sys.test.property}"));
+        Assert.assertEquals("defaultValue", Expressions.resolve(PROPERTIES, "${sys.invalid.property:defaultValue}"));
+    }
+
+    @Test
+    public void testProperties() {
+        Assert.assertEquals("test property value", Expressions.resolve(PROPERTIES, "${test.property}"));
+        Assert.assertEquals("defaultValue", Expressions.resolve(PROPERTIES, "${invalid.property:defaultValue}"));
+    }
+}


### PR DESCRIPTION
… used for expressions in addition to the passed in properties file.

Added documentation about expressions.

https://issues.jboss.org/browse/LOGTOOL-127