### PR TITLE
Attempt to reduce metaspace in the generated files

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/ImplementationClassModel.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/ImplementationClassModel.java
@@ -96,6 +96,7 @@ import org.jboss.logging.processor.util.ElementHelper;
 abstract class ImplementationClassModel extends ClassModel {
 
     private final AtomicBoolean messageFormatMethodGenerated = new AtomicBoolean(false);
+    private final AtomicBoolean copyStackTraceMethodGenerated = new AtomicBoolean(false);
     private final TypeMirror stringType;
 
     /**
@@ -252,10 +253,10 @@ abstract class ImplementationClassModel extends ClassModel {
             if (isSupplier) {
                 final JLambda lambda = JExprs.lambda();
                 final JBlock lambdaBody = lambda.body();
-                lambdaBody._return(createReturnType(messageMethod, lambdaBody, formatterCall, fields, properties));
+                lambdaBody._return(createReturnType(classDef, messageMethod, lambdaBody, formatterCall, fields, properties));
                 result = lambda;
             } else {
-                result = createReturnType(messageMethod, body, formatterCall, fields, properties);
+                result = createReturnType(classDef, messageMethod, body, formatterCall, fields, properties);
             }
         } else {
             if (isSupplier) {
@@ -380,7 +381,7 @@ abstract class ImplementationClassModel extends ClassModel {
         }
     }
 
-    private JExpr createReturnType(final MessageMethod messageMethod, final JBlock body, final JCall format, final Map<String, JParamDeclaration> fields, final Map<String, JParamDeclaration> properties) {
+    private JExpr createReturnType(final JClassDef classDef, final MessageMethod messageMethod, final JBlock body, final JCall format, final Map<String, JParamDeclaration> fields, final Map<String, JParamDeclaration> properties) {
         boolean callInitCause = false;
         final Set<Parameter> producers = messageMethod.parametersAnnotatedWith(Producer.class);
         final JType type;
@@ -472,10 +473,7 @@ abstract class ImplementationClassModel extends ClassModel {
         addDefultProperties(messageMethod, ElementHelper.getAnnotations(messageMethod, Fields.class, Field.class), body, $v(resultField), true);
 
         // Remove this caller from the stack trace
-        final JType arrays = $t(Arrays.class);
-        sourceFile._import(arrays);
-        final JVarDeclaration st = body.var(FINAL, $t(StackTraceElement.class).array(), "st", $v(resultField).call("getStackTrace"));
-        body.add($v(resultField).call("setStackTrace").arg(arrays.call("copyOfRange").arg($v(st)).arg(JExpr.ONE).arg($v(st).field("length"))));
+        body.add(getCopyStackMethod(classDef).arg($v(resultField)));
 
         // Add any suppressed messages
         final Set<Parameter> suppressed = messageMethod.parametersAnnotatedWith(Suppressed.class);
@@ -603,6 +601,23 @@ abstract class ImplementationClassModel extends ClassModel {
             );
         }
 
+        return JExprs.call(methodName);
+    }
+
+    private JCall getCopyStackMethod(final JClassDef classDef) {
+        final String methodName = "_copyStackTraceMinusOne";
+
+        if (copyStackTraceMethodGenerated.compareAndSet(false, true)) {
+            final JMethodDef method = classDef.method(JMod.PRIVATE | JMod.STATIC, JType.VOID, methodName);
+            final JParamDeclaration param = method.param(JMod.FINAL, Throwable.class, "e");
+            final JBlock body = method.body();
+            // Remove this caller from the stack trace
+            final JType arrays = $t(Arrays.class);
+            sourceFile._import(arrays);
+            final JExpr e = $v(param);
+            final JVarDeclaration st = body.var(FINAL, $t(StackTraceElement.class).array(), "st", e.call("getStackTrace"));
+            body.add(e.call("setStackTrace").arg(arrays.call("copyOfRange").arg($v(st)).arg(JExpr.ONE).arg($v(st).field("length"))));
+        }
         return JExprs.call(methodName);
     }
 

--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/ImplementationClassModel.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/ImplementationClassModel.java
@@ -517,6 +517,9 @@ abstract class ImplementationClassModel extends ClassModel {
         if (!param.isPrimitive()) {
             sourceFile._import(paramType);
         }
+        if (param.isVarArgs()) {
+            return method.varargParam(FINAL, paramType.elementType(), param.name());
+        }
         return method.param(FINAL, paramType, param.name());
     }
 


### PR DESCRIPTION
## [LOGTOOL-129](https://issues.jboss.org/browse/LOGTOOL-129)
Removes the generation of the stack trace copy/replace on each bundle message that returns an exception. Adds a single method to the implementation that can be invoked from each bundle message instead.

## [LOGTOOL-130](https://issues.jboss.org/browse/LOGTOOL-130)
This is a change from the original specs of what the tooling should do. However I see no need for the private static constants to exist. This removes the private static constants and instead just returns the hard-coded message in the `message$str()` method. [Reference to the original requirements.
](https://developer.jboss.org/wiki/LoggingI18nToolingTechnicalRequirements).

## [LOGTOOL-131](https://issues.jboss.org/browse/LOGTOOL-131)
This is not a required change, but just felt needed for consistency. This just ensures if the interface method is a varargs method, the implementation method will also be a varargs method instead of just an array parameter.
