### PR TITLE
[Preview] Add an ExceptedLog JUnit utility to allow users to assert something is being logged in their tests

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-tools-parent</artifactId>
-        <version>2.1.1.Final-SNAPSHOT</version>
+        <version>2.2.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-tools-parent</artifactId>
-        <version>2.1.1.Final-SNAPSHOT</version>
+        <version>2.2.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.jboss.jdeparser>2.0.2.Final</version.org.jboss.jdeparser>
-        <version.org.jboss.logging>3.1.2.GA</version.org.jboss.logging>
+        <version.org.jboss.logging>3.4.0.Final-SNAPSHOT</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.0.3.Final</version.org.jboss.logmanager>
         <verion.org.jboss.forge.roaster>2.19.2.Final</verion.org.jboss.forge.roaster>
         <version.junit>4.12</version.junit>
@@ -142,5 +142,6 @@
         <module>processor</module>
         <module>processor-tests</module>
         <module>docs</module>
+        <module>test-junit4</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>org.jboss.logging</groupId>
     <artifactId>jboss-logging-tools-parent</artifactId>
-    <version>2.1.1.Final-SNAPSHOT</version>
+    <version>2.2.0.Final-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>JBoss Logging Tools Parent</name>

--- a/processor-tests/pom.xml
+++ b/processor-tests/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-tools-parent</artifactId>
-        <version>2.1.1.Final-SNAPSHOT</version>
+        <version>2.2.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging-tools-parent</artifactId>
-        <version>2.1.1.Final-SNAPSHOT</version>
+        <version>2.2.0.Final-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-junit4/pom.xml
+++ b/test-junit4/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2015 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging-tools-parent</artifactId>
+        <version>2.2.0.Final-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>jboss-logging-test-utils</artifactId>
+    <packaging>jar</packaging>
+
+    <name>JBoss Logging Test Utilities</name>
+
+    <licenses>
+        <license>
+            <name>Apache License, version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-junit4/src/main/java/org/jboss/logging/test/junit4/ExpectedLog.java
+++ b/test-junit4/src/main/java/org/jboss/logging/test/junit4/ExpectedLog.java
@@ -1,0 +1,270 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.test.junit4;
+
+import org.hamcrest.*;
+import org.jboss.logging.Logger;
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+
+import java.util.*;
+
+import static org.junit.Assert.fail;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class ExpectedLog implements TestRule {
+
+	/**
+	 * Returns a {@linkplain TestRule rule} that does not mandate any particular log to be produced (identical to
+	 * behavior without this rule).
+	 */
+	public static ExpectedLog create() {
+		return new ExpectedLog();
+	}
+
+	private final ListenableDelegatingLogger logger;
+
+	private List<Matcher<?>> expectations = new ArrayList<>();
+
+	private List<Matcher<?>> absenceExpectations = new ArrayList<>();
+
+	private ExpectedLog() {
+		this(Logger.getLogger(""));
+	}
+
+	public ExpectedLog(Logger logger) {
+		this.logger = LogInspectionHelper.convertType(logger);
+	}
+
+	@Override
+	public Statement apply(Statement base, org.junit.runner.Description description) {
+		return new ExpectedLogStatement(base);
+	}
+
+	/**
+	 * Verify that your code produces a log event matching the given matcher.
+	 */
+	public void expectEvent(Matcher<? extends LoggingEvent> matcher) {
+		expectations.add(matcher);
+	}
+
+	/**
+	 * Verify that your code <strong>doesn't</strong> produce a log event matching the given matcher.
+	 */
+	public void expectEventMissing(Matcher<? extends LoggingEvent> matcher) {
+		absenceExpectations.add(matcher);
+	}
+
+	/**
+	 * Verify that your code <strong>doesn't</strong> produce a log event matching the given level or higher.
+	 */
+	public void expectLevelOrHigherMissing(Logger.Level level) {
+		expectEventMissing(hasLevelOrHigher(level));
+	}
+
+	/**
+	 * Verify that your code produces a log message containing the given string.
+	 */
+	public void expectMessage(String containedString) {
+		expectMessage(CoreMatchers.containsString(containedString));
+	}
+
+	/**
+	 * Verify that your code <strong>doesn't</strong> produce a log message containing the given string.
+	 */
+	public void expectMessageMissing(String containedString) {
+		expectMessageMissing(CoreMatchers.containsString(containedString));
+	}
+
+	/**
+	 * Verify that your code produces a log message containing all of the given strings.
+	 */
+	public void expectMessage(String containedString, String... otherContainedStrings) {
+		expectMessage(containsAllStrings(containedString, otherContainedStrings));
+	}
+
+	/**
+	 * Verify that your code <strong>doesn't</strong> produce a log message containing all of the given strings.
+	 */
+	public void expectMessageMissing(String containedString, String... otherContainedStrings) {
+		expectMessageMissing(containsAllStrings(containedString, otherContainedStrings));
+	}
+
+	/**
+	 * Verify that your code produces a log event at the given level and with a message containing all of the given strings.
+	 */
+	public void expectEvent(Logger.Level level, String containedString, String... otherContainedStrings) {
+		expectEvent(CoreMatchers.allOf(hasLevel(level),
+				eventMessageMatcher(containsAllStrings(containedString, otherContainedStrings))));
+	}
+
+	/**
+	 * Verify that your code <strong>doesn't</strong> produce a log event at the given level and
+	 * with a message containing all of the given strings.
+	 */
+	public void expectEventMissing(Logger.Level level, String containedString, String... otherContainedStrings) {
+		expectEventMissing(CoreMatchers.allOf(hasLevel(level),
+				eventMessageMatcher(containsAllStrings(containedString, otherContainedStrings))));
+	}
+
+	/**
+	 * Verify that your code produces a log message matches the given Hamcrest matcher.
+	 */
+	public void expectMessage(Matcher<String> matcher) {
+		expectEvent(eventMessageMatcher(matcher));
+	}
+
+	/**
+	 * Verify that your code <strong>doesn't</strong> produce a log message matches the given Hamcrest matcher.
+	 */
+	public void expectMessageMissing(Matcher<String> matcher) {
+		expectEventMissing(eventMessageMatcher(matcher));
+	}
+
+	private Matcher<LoggingEvent> hasLevelOrHigher(Logger.Level level) {
+		return new TypeSafeMatcher<LoggingEvent>() {
+			@Override
+			public void describeTo(Description description) {
+				description.appendText( "a LoggingEvent with " ).appendValue( level ).appendText( " level or higher" );
+			}
+			@Override
+			protected boolean matchesSafely(LoggingEvent item) {
+				return level.compareTo( item.getLevel() ) >= 0;
+			}
+		};
+	}
+
+	private Matcher<LoggingEvent> hasLevel(Logger.Level level) {
+		return new TypeSafeMatcher<LoggingEvent>() {
+			@Override
+			public void describeTo(Description description) {
+				description.appendText( "a LoggingEvent with " ).appendValue( level ).appendText( " level" );
+			}
+			@Override
+			protected boolean matchesSafely(LoggingEvent item) {
+				return level.equals( item.getLevel() );
+			}
+		};
+	}
+
+	private Matcher<String> containsAllStrings(String containedString, String... otherContainedStrings) {
+		Collection<Matcher<? super String>> matchers = new ArrayList<>();
+		matchers.add(CoreMatchers.containsString(containedString));
+		for (String otherContainedString : otherContainedStrings) {
+			matchers.add(CoreMatchers.containsString(otherContainedString));
+		}
+		return CoreMatchers.allOf(matchers);
+	}
+
+	private Matcher<LoggingEvent> eventMessageMatcher(final Matcher<String> messageMatcher) {
+		return new TypeSafeMatcher<LoggingEvent>() {
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("a LoggingEvent with message matching ");
+				messageMatcher.describeTo(description);
+			}
+
+			@Override
+			protected boolean matchesSafely(LoggingEvent item) {
+				return messageMatcher.matches(item.getRenderedMessage());
+			}
+		};
+	}
+
+	private class Listener implements LogListener {
+		private final Set<Matcher<?>> expectationsMet = new HashSet<>();
+		private final Set<LoggingEvent> unexpectedEvents = new HashSet<>();
+
+		@Override
+		public void loggedEvent(LoggingEvent event) {
+			for (Matcher<?> expectation : ExpectedLog.this.expectations) {
+				if (!expectationsMet.contains(expectation) && expectation.matches(event)) {
+					expectationsMet.add(expectation);
+				}
+			}
+			for (Matcher<?> absenceExpectation : ExpectedLog.this.absenceExpectations) {
+				if (absenceExpectation.matches(event)) {
+					unexpectedEvents.add(event);
+				}
+			}
+		}
+
+		public Set<Matcher<?>> getExpectationsNotMet() {
+			Set<Matcher<?>> expectationsNotMet = new HashSet<>();
+			expectationsNotMet.addAll(expectations);
+			expectationsNotMet.removeAll(expectationsMet);
+			return expectationsNotMet;
+		}
+
+		public Set<LoggingEvent> getUnexpectedEvents() {
+			return unexpectedEvents;
+		}
+
+	}
+
+	private class ExpectedLogStatement extends Statement {
+
+		private final Statement next;
+
+		public ExpectedLogStatement(Statement base) {
+			next = base;
+		}
+
+		@Override
+		public void evaluate() throws Throwable {
+			Listener listener = new Listener();
+			logger.getListenable().registerListener(listener);
+			try {
+				next.evaluate();
+			} finally {
+				logger.getListenable().unregisterListener(listener);
+			}
+			Set<Matcher<?>> expectationsNotMet = listener.getExpectationsNotMet();
+			Set<LoggingEvent> unexpectedEvents = listener.getUnexpectedEvents();
+			if (!expectationsNotMet.isEmpty() || !unexpectedEvents.isEmpty()) {
+				fail(buildFailureMessage(expectationsNotMet, unexpectedEvents));
+			}
+		}
+	}
+
+	private static String buildFailureMessage(Set<Matcher<?>> missingSet, Set<LoggingEvent> unexpectedEvents) {
+		Description description = new StringDescription();
+		description.appendText("Produced logs did not meet the expectations.");
+		if (!missingSet.isEmpty()) {
+			description.appendText("\nMissing logs:");
+			for (Matcher<?> missing : missingSet) {
+				description.appendText("\n\t");
+				missing.describeTo(description);
+			}
+		}
+		if (!unexpectedEvents.isEmpty()) {
+			description.appendText("\nUnexpected logs:");
+			for (LoggingEvent unexpected : unexpectedEvents) {
+				description.appendText("\n\t");
+				description.appendText(unexpected.getRenderedMessage());
+			}
+		}
+		return description.toString();
+	}
+
+}

--- a/test-junit4/src/main/java/org/jboss/logging/test/junit4/ListenableDelegatingLogger.java
+++ b/test-junit4/src/main/java/org/jboss/logging/test/junit4/ListenableDelegatingLogger.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.test.junit4;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+
+import org.jboss.logging.Logger;
+
+/**
+ * A {@code Logger} implementation which delegates to another one
+ * but makes it possible to test for events being logged (not logged).
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2015 Red Hat Inc.
+ */
+final class ListenableDelegatingLogger extends Logger {
+
+	private final Logger delegate;
+	private final LogListenable listenable;
+
+	ListenableDelegatingLogger(String name, Logger delegate, LogListenable listenable) {
+		super( name );
+		this.delegate = delegate;
+		this.listenable = listenable;
+	}
+
+	public LogListenable getListenable() {
+		return listenable;
+	}
+
+	@Override
+	public boolean isEnabled(final Level level) {
+		// We want users to think this logger is enabled, so as to detect all logger calls
+		return listenable.isEnabled() || delegate.isEnabled(level);
+	}
+
+	@Override
+	protected void doLog(final Level level, final String loggerClassName, final Object message, final Object[] parameters, final Throwable thrown) {
+		if ( listenable.isEnabled() ) {
+			LoggingEvent event = new LoggingEvent(
+					getName(), loggerClassName, level,
+					parameters == null || parameters.length == 0 ? String.valueOf( message )
+							: new MessageFormat( String.valueOf( message ), Locale.getDefault() ).format( parameters ),
+					thrown );
+			listenable.notify( event );
+		}
+		delegate.log( loggerClassName, level, message, parameters, thrown );
+	}
+
+	@Override
+	protected void doLogf(final Level level, final String loggerClassName, final String format, final Object[] parameters, final Throwable thrown) {
+		if ( listenable.isEnabled() ) {
+			LoggingEvent event = new LoggingEvent(
+					getName(), loggerClassName, level,
+					parameters == null ? format : String.format( Locale.getDefault(), format, parameters ),
+					thrown );
+			listenable.notify( event );
+		}
+		delegate.logf( loggerClassName, level, thrown, format, parameters );
+	}
+}

--- a/test-junit4/src/main/java/org/jboss/logging/test/junit4/LogInspectionHelper.java
+++ b/test-junit4/src/main/java/org/jboss/logging/test/junit4/LogInspectionHelper.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.test.junit4;
+
+import java.lang.reflect.Field;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.DelegatingBasicLogger;
+
+/**
+ * Test helper to listen for logging events.
+ * For this to work, it requires JBoss Logging to pick up our custom
+ * implementation {@code Log4DelegatingLogger} via ServiceLoader.
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2015 Red Hat Inc.
+ */
+final class LogInspectionHelper {
+
+	private LogInspectionHelper() {
+	}
+
+	public static ListenableDelegatingLogger convertType(BasicLogger log) {
+		if ( log instanceof DelegatingBasicLogger ) {
+			//Most loggers generated via the annotation processor are of this type
+			DelegatingBasicLogger wrapper = (DelegatingBasicLogger) log;
+			try {
+				return extractFromWrapper( wrapper );
+			}
+			catch (Exception cause) {
+				throw new RuntimeException( cause );
+			}
+		}
+		if ( ! ( log instanceof ListenableDelegatingLogger ) ) {
+			throw new IllegalStateException( "Unexpected log type: JBoss Logger didn't register the custom TestableLoggerProvider as logger provider" );
+		}
+		return (ListenableDelegatingLogger) log;
+	}
+
+	private static ListenableDelegatingLogger extractFromWrapper(DelegatingBasicLogger wrapper) throws Exception {
+		Field field = DelegatingBasicLogger.class.getDeclaredField( "log" );
+		field.setAccessible( true );
+		Object object = field.get( wrapper );
+		return convertType( (BasicLogger) object );
+	}
+
+}

--- a/test-junit4/src/main/java/org/jboss/logging/test/junit4/LogListenable.java
+++ b/test-junit4/src/main/java/org/jboss/logging/test/junit4/LogListenable.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.test.junit4;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class LogListenable {
+
+	// Synchronize access on the field
+	private final List<LogListener> enabledListeners = new LinkedList<>();
+	private final AtomicBoolean interceptEnabled = new AtomicBoolean( false );
+
+	void registerListener(LogListener newListener) {
+		synchronized (enabledListeners) {
+			if ( newListener != null ) {
+				enabledListeners.add( newListener );
+				interceptEnabled.set( true );
+			}
+		}
+	}
+
+	void unregisterListener(LogListener listener) {
+		synchronized (enabledListeners) {
+			enabledListeners.remove( listener );
+			if ( enabledListeners.isEmpty() ) {
+				interceptEnabled.set( false );
+			}
+		}
+	}
+
+	boolean isEnabled() {
+		return interceptEnabled.get();
+	}
+
+	void notify(LoggingEvent event) {
+		synchronized (enabledListeners) {
+			for ( LogListener listener : enabledListeners ) {
+				listener.loggedEvent( event );
+			}
+		}
+	}
+}

--- a/test-junit4/src/main/java/org/jboss/logging/test/junit4/LogListener.java
+++ b/test-junit4/src/main/java/org/jboss/logging/test/junit4/LogListener.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.test.junit4;
+
+interface LogListener {
+	void loggedEvent(LoggingEvent event);
+}

--- a/test-junit4/src/main/java/org/jboss/logging/test/junit4/LoggingEvent.java
+++ b/test-junit4/src/main/java/org/jboss/logging/test/junit4/LoggingEvent.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.test.junit4;
+
+import org.jboss.logging.Logger;
+
+public final class LoggingEvent {
+	private final String loggerName;
+	private final String loggerFqcn;
+	private final Logger.Level level;
+	private final String renderedMessage;
+	private final Throwable thrown;
+
+	LoggingEvent(
+			String loggerName,
+			String loggerFqcn,
+			Logger.Level level,
+			String renderedMessage,
+			Throwable thrown) {
+		this.loggerName = loggerName;
+		this.loggerFqcn = loggerFqcn;
+		this.level = level;
+		this.renderedMessage = renderedMessage;
+		this.thrown = thrown;
+	}
+
+	public String getLoggerName() {
+		return loggerName;
+	}
+
+	public String getLoggerFqcn() {
+		return loggerFqcn;
+	}
+
+	public Logger.Level getLevel() {
+		return level;
+	}
+
+	public String getRenderedMessage() {
+		return renderedMessage;
+	}
+
+	public Throwable getThrown() {
+		return thrown;
+	}
+}

--- a/test-junit4/src/main/java/org/jboss/logging/test/junit4/TestableLoggerProvider.java
+++ b/test-junit4/src/main/java/org/jboss/logging/test/junit4/TestableLoggerProvider.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.test.junit4;
+
+import org.jboss.logging.DelegatingLoggerProvider;
+import org.jboss.logging.Logger;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A {@code LoggerProvider} for JBoss Logger.
+ * See also META-INF/services/org.jboss.logging.LoggerProvider
+ *
+ * @author Sanne Grinovero <sanne@hibernate.org> (C) 2015 Red Hat Inc.
+ */
+public final class TestableLoggerProvider extends DelegatingLoggerProvider {
+
+	//We LEAK Logger instances: good only for testing as we know the set of categories is limited in practice
+	private final ConcurrentMap<String, Logger> reuseLoggerInstances = new ConcurrentHashMap<>();
+
+	private final LogListenable listenable = new LogListenable();
+
+	@Override
+	public Logger getLogger(final String name) {
+		Logger logger = reuseLoggerInstances.get( name );
+		if ( logger == null ) {
+			Logger delegateLogger = getDelegate().getLogger( name );
+			logger = new ListenableDelegatingLogger( "".equals( name ) ? "ROOT" : name, delegateLogger, listenable );
+			Logger previous = reuseLoggerInstances.putIfAbsent( name, logger );
+			if ( previous != null ) {
+				return previous;
+			}
+		}
+		return logger;
+	}
+}

--- a/test-junit4/src/main/resources/META-INF/LICENSE.txt
+++ b/test-junit4/src/main/resources/META-INF/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/test-junit4/src/main/resources/META-INF/services/org.jboss.logging.LoggerProvider
+++ b/test-junit4/src/main/resources/META-INF/services/org.jboss.logging.LoggerProvider
@@ -1,0 +1,1 @@
+org.jboss.logging.test.junit4.TestableLoggerProvider

--- a/test-junit4/src/test/java/org/jboss/logging/test/junit4/ExpectedLogTest.java
+++ b/test-junit4/src/test/java/org/jboss/logging/test/junit4/ExpectedLogTest.java
@@ -1,0 +1,527 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.test.junit4;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class ExpectedLogTest {
+
+	@Test
+	public void expectEvent_customMatcher() throws Throwable {
+		final String expectedMessage = "<expected log message>";
+		final String matcherDescription = "<matcher description>";
+		final Matcher<LoggingEvent> matcher = new TypeSafeMatcher<LoggingEvent>() {
+			@Override
+			protected boolean matchesSafely(LoggingEvent item) {
+				return item.getRenderedMessage().equals(expectedMessage);
+			}
+
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+				description.appendText(matcherDescription);
+			}
+		};
+
+		// Log present
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEvent(matcher);
+				logger.info(expectedMessage);
+			}
+		});
+
+		// No matching log
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEvent(matcher);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEvent(matcher);
+			}
+		});
+	}
+
+	@Test
+	public void expectEventMissing_customMatcher() throws Throwable {
+		final String expectedMessage = "<expected log message>";
+		final String matcherDescription = "<matcher description>";
+		final Matcher<LoggingEvent> matcher = new TypeSafeMatcher<LoggingEvent>() {
+			@Override
+			protected boolean matchesSafely(LoggingEvent item) {
+				return item.getRenderedMessage().equals(expectedMessage);
+			}
+
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+				description.appendText(matcherDescription);
+			}
+		};
+
+		// Log present
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEventMissing(matcher);
+				logger.info(expectedMessage);
+			}
+		});
+
+		// No matching log
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEventMissing(matcher);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEventMissing(matcher);
+			}
+		});
+	}
+
+	@Test
+	public void expectLevelOrHigherMissing() throws Throwable {
+		// Exact level
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectLevelOrHigherMissing(Logger.Level.WARN);
+				logger.warn("exact level");
+			}
+		});
+
+		// Higher level
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectLevelOrHigherMissing(Logger.Level.WARN);
+				logger.error("higher level");
+			}
+		});
+
+		// Lower level
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectLevelOrHigherMissing(Logger.Level.WARN);
+				logger.info("lower level");
+			}
+		});
+
+		// No log at all
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectLevelOrHigherMissing(Logger.Level.WARN);
+			}
+		});
+	}
+
+	@Test
+	public void expectMessage_singleString() throws Throwable {
+		final String expectedMessage = "<expected log message>";
+
+		// Log present
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(expectedMessage);
+				logger.info("foo " + expectedMessage + " bar");
+			}
+		});
+
+		// No matching log
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(expectedMessage);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(expectedMessage);
+			}
+		});
+	}
+
+	@Test
+	public void expectMessageMissing_singleString() throws Throwable {
+		final String expectedMessage = "<expected log message>";
+
+		// Log present
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(expectedMessage);
+				logger.info("foo " + expectedMessage + " bar");
+			}
+		});
+
+		// No matching log
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(expectedMessage);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(expectedMessage);
+			}
+		});
+	}
+
+	@Test
+	public void expectMessage_multipleStrings() throws Throwable {
+		final String expectedMessagePart1 = "<expected log message part 1>";
+		final String expectedMessagePart2 = "<expected log message part 2>";
+
+		// Log present
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(expectedMessagePart1, expectedMessagePart2);
+				logger.info("foo " + expectedMessagePart2 + " bar " + expectedMessagePart1 + " foobar");
+			}
+		});
+
+		// Log only partially present
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(expectedMessagePart1, expectedMessagePart2);
+				logger.info("foo " + expectedMessagePart2 + " bar");
+			}
+		});
+
+		// No matching log
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(expectedMessagePart1, expectedMessagePart2);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(expectedMessagePart1, expectedMessagePart2);
+			}
+		});
+	}
+
+	@Test
+	public void expectMessageMissing_multipleStrings() throws Throwable {
+		final String expectedMessagePart1 = "<expected log message part 1>";
+		final String expectedMessagePart2 = "<expected log message part 2>";
+
+		// Log present
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(expectedMessagePart1, expectedMessagePart2);
+				logger.info("foo " + expectedMessagePart2 + " bar " + expectedMessagePart1 + " foobar");
+			}
+		});
+
+		// Log only partially present
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(expectedMessagePart1, expectedMessagePart2);
+				logger.info("foo " + expectedMessagePart2 + " bar");
+			}
+		});
+
+		// No matching log
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(expectedMessagePart1, expectedMessagePart2);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(expectedMessagePart1, expectedMessagePart2);
+			}
+		});
+	}
+
+	@Test
+	public void expectEvent_levelAndMessages() throws Throwable {
+		final String expectedMessagePart1 = "<expected log message part 1>";
+		final String expectedMessagePart2 = "<expected log message part 2>";
+
+		// Log present
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEvent(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+				logger.info("foo " + expectedMessagePart2 + " bar " + expectedMessagePart1 + " foobar");
+			}
+		});
+
+		// Log only partially present (partial message)
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEvent(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+				logger.info("foo " + expectedMessagePart2 + " bar");
+			}
+		});
+
+		// Log only partially present (wrong level)
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEvent(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+				logger.warn("foo " + expectedMessagePart2 + " bar " + expectedMessagePart1 + " foobar");
+			}
+		});
+
+		// No matching log
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEvent(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEvent(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+			}
+		});
+	}
+
+	@Test
+	public void expectEventMissing_levelAndMessages() throws Throwable {
+		final String expectedMessagePart1 = "<expected log message part 1>";
+		final String expectedMessagePart2 = "<expected log message part 2>";
+
+		// Log present
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEventMissing(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+				logger.info("foo " + expectedMessagePart2 + " bar " + expectedMessagePart1 + " foobar");
+			}
+		});
+
+		// Log only partially present (partial message)
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEventMissing(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+				logger.info("foo " + expectedMessagePart2 + " bar");
+			}
+		});
+
+		// Log only partially present (wrong level)
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEventMissing(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+				logger.warn("foo " + expectedMessagePart2 + " bar " + expectedMessagePart1 + " foobar");
+			}
+		});
+
+		// No matching log
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEventMissing(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectEventMissing(Logger.Level.INFO, expectedMessagePart1, expectedMessagePart2);
+			}
+		});
+	}
+
+	@Test
+	public void expectMessage_customMatcher() throws Throwable {
+		final String expectedMessage = "<expected log message>";
+		final String matcherDescription = "<matcher description>";
+		final Matcher<String> matcher = new TypeSafeMatcher<String>() {
+			@Override
+			protected boolean matchesSafely(String item) {
+				return item.equals(expectedMessage);
+			}
+
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+				description.appendText(matcherDescription);
+			}
+		};
+
+		// Log present
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(matcher);
+				logger.info(expectedMessage);
+			}
+		});
+
+		// No matching log
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(matcher);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessage(matcher);
+			}
+		});
+	}
+
+	@Test
+	public void expectMessageMissing_customMatcher() throws Throwable {
+		final String expectedMessage = "<expected log message>";
+		final String matcherDescription = "<matcher description>";
+		final Matcher<String> matcher = new TypeSafeMatcher<String>() {
+			@Override
+			protected boolean matchesSafely(String item) {
+				return item.equals(expectedMessage);
+			}
+
+			@Override
+			public void describeTo(org.hamcrest.Description description) {
+				description.appendText(matcherDescription);
+			}
+		};
+
+		// Log present
+		assertFailure(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(matcher);
+				logger.info(expectedMessage);
+			}
+		});
+
+		// No matching log
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(matcher);
+				logger.info("non-matching");
+				logger.error("other non-matching");
+			}
+		});
+
+		// No log at all
+		assertSuccess(new TestStatement() {
+			@Override
+			public void execute(Logger logger, ExpectedLog rule) {
+				rule.expectMessageMissing(matcher);
+			}
+		});
+	}
+
+	private void assertSuccess(TestStatement statement) throws Throwable {
+		AssertionError error = runSafely(statement);
+		Assert.assertNull("Expected no error, got " + error, error);
+	}
+
+	private void assertFailure(TestStatement statement) throws Throwable {
+		AssertionError error = runSafely(statement);
+		Assert.assertNotNull("Expected an error, got success", error);
+	}
+
+	private AssertionError runSafely(TestStatement statement) throws Throwable {
+		try {
+			Logger logger = Logger.getLogger(getClass());
+			ExpectedLog testedRule = ExpectedLog.create();
+			Statement junitStatement = new Statement() {
+				@Override
+				public void evaluate() throws Throwable {
+					statement.execute(logger, testedRule);
+				}
+			};
+			testedRule.apply(junitStatement, Description.EMPTY).evaluate();
+			return null; // No failure
+		}
+		catch (AssertionError assertionError) {
+			return assertionError;
+		}
+	}
+
+	private interface TestStatement {
+		void execute(Logger logger, ExpectedLog rule);
+	}
+}


### PR DESCRIPTION
As per your discussion with Sanne, here is the utility we use in Hibernate projects, adapted to be agnostic with respect to the actual logging provider, and augmented with methods we use in another utility (from the Hibernate Search project).

The purpose of this utility is to allow users to add assertions in their tests checking that a given logging event occurred, or on the contrary that a given logging event did not occur (no error, for instance).

The utility requires JUnit 4.

I pushed everything to a sub-project of the JBoss Logging Tools, but let me know if there is a better place for this code.

There is no documentation for now, I would like a confirmation that you think it's worth adding to your project first.

One downside: I had to add an abstract `DelegatingLoggerProvider` class to the main JBoss Logging project in order for this to work at all, otherwise we cannot forward logging events to an actual logging implementation. Here is the PR: https://github.com/jboss-logging/jboss-logging/pull/26

Usage:

```
public class MyTest {

  @Rule
  public final ExpectedLog logged = ExpectedLog.create();

  @Test
  public void test() {
    // ... do stuff ...
    // Declare that, between now and the end of this test method, we expect this log message
    logged.expectEvent(Logger.Level.ERROR, "some log message");
    // ... do stuff ...
    // The test will fail if the log message hasn't been detected at this point 
  }

  @Test
  public void test2() {
    // ... do stuff ...
    // Declare that, between now and the end of this test method, we do *not* expect this log message
    logged.expectEvent(Logger.Level.ERROR, "some log message");
    // ... do stuff ...
    // The test will fail if the log message has been detected at this point
  }
}
```

