### PR TITLE
[LOGTOOL-140] Upgrade jdeparser from 2.0.2.Final to 2.0.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.org.jboss.jdeparser>2.0.2.Final</version.org.jboss.jdeparser>
+        <version.org.jboss.jdeparser>2.0.3.Final</version.org.jboss.jdeparser>
         <version.org.jboss.logging>3.4.0.Final</version.org.jboss.logging>
         <version.org.jboss.logmanager>2.1.9.Final</version.org.jboss.logmanager>
         <verion.org.jboss.forge.roaster>2.20.8.Final</verion.org.jboss.forge.roaster>


### PR DESCRIPTION
https://issues.jboss.org/browse/LOGTOOL-140