### PR TITLE
Fix compilation error on JDK 13

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/model/DelegatingExecutableElement.java
+++ b/processor/src/main/java/org/jboss/logging/processor/model/DelegatingExecutableElement.java
@@ -42,6 +42,11 @@ public interface DelegatingExecutableElement extends ExecutableElement, Delegati
     ExecutableElement getDelegate();
 
     @Override
+    default TypeMirror asType() {
+        return getDelegate().asType();
+    }
+
+    @Override
     default List<? extends TypeParameterElement> getTypeParameters() {
         return getDelegate().getTypeParameters();
     }

--- a/processor/src/main/java/org/jboss/logging/processor/model/DelegatingTypeElement.java
+++ b/processor/src/main/java/org/jboss/logging/processor/model/DelegatingTypeElement.java
@@ -42,6 +42,11 @@ public interface DelegatingTypeElement extends TypeElement, DelegatingElement {
     TypeElement getDelegate();
 
     @Override
+    default TypeMirror asType() {
+        return getDelegate().asType();
+    }
+
+    @Override
     default List<? extends Element> getEnclosedElements() {
         return getDelegate().getEnclosedElements();
     }


### PR DESCRIPTION
JDK 13 added `asType` to `javax.lang.model.element.ExecutableElement`and `javax.lang.model.element.TypeElement`