### PR TITLE
[LOGTOOL-143] Add the ability to write the index parameter to each fo…

### DIFF
--- a/docs/src/main/asciidoc/processor-options.adoc
+++ b/docs/src/main/asciidoc/processor-options.adoc
@@ -28,6 +28,7 @@ include::expressions.adoc[]
 | `skipTranslations` | If set to `true` source files with the translated tet will not be generated. The default is `false`.
 | `generatedTranslationFilesPath` | If defined this indicates the path a skeleton file should be generated for the interface. The generated skeleton file will be placed in a directory that matches the package with a name that matches the interface with a `.i18n_locale_COUNTRY_VARIANT.properties` suffix.
 | `org.jboss.logging.tools.level` | Sets the maximum level to include in the generated skeleton files. For example if set to `INFO` the skeleton files will not contain any properties where the log level was set to `DEBUG` or `TRACE`.
+| `org.jboss.logging.tools.generated.skip.index` | By default when generating a skeleton translation file an index will be appended to the format pattern. For example `Example %s and %d` becomes `Example %1$s and %2$d`. This option allows this behavior to be disabled.
 
 |===
 

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -151,6 +151,7 @@
                         <test.generated.src.path>${project.build.directory}/generated-test-sources/test-annotations</test.generated.src.path>
                         <test.report.path>${test.report.path}</test.report.path>
                         <test.property>sysValue</test.property>
+                        <test.skeleton.file.path>${project.build.testOutputDirectory}</test.skeleton.file.path>
                         <expressionPropertiesPath>${expression.properties.path}</expressionPropertiesPath>
                     </systemPropertyVariables>
                 </configuration>

--- a/processor/src/test/java/org/jboss/logging/processor/generated/GeneratedSkeletonTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/GeneratedSkeletonTest.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.logging.processor.generated;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Date;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class GeneratedSkeletonTest {
+
+    private static final String DIR = System.getProperty("test.skeleton.file.path");
+
+    @Test
+    public void testLoggerIndexes() throws Exception {
+        final Properties properties = resolveProperties(StringFormatLogger.class);
+        Assert.assertEquals("String %1$s integer %2$d", properties.getProperty("stringInt"));
+        Assert.assertEquals("Duke's Birthday: %1$tm %<te,%<tY", properties.getProperty("dukesBirthday"));
+        Assert.assertEquals("The error is %1$s, I repeat %1$s", properties.getProperty("repeat"));
+    }
+
+    @Test
+    public void testMessageBundleIndexes() throws Exception {
+        final Properties properties = resolveProperties(StringFormatMessages.class);
+        String foundFormat = properties.getProperty("stringInt");
+        test("String %1$s integer %2$d", foundFormat, "value1", 2);
+        Assert.assertEquals(StringFormatMessages.MESSAGES.stringInt("value1", 2), String.format(foundFormat, "value1", 2));
+
+        foundFormat = properties.getProperty("dukesBirthday");
+        test("Duke's Birthday: %1$tm %<te,%<tY", foundFormat, new Date());
+        final Date date = new Date();
+        Assert.assertEquals(StringFormatMessages.MESSAGES.dukesBirthday(date), String.format(foundFormat, date));
+
+        foundFormat = properties.getProperty("repeat");
+        test("The error is %1$s, I repeat %1$s", foundFormat, "value1");
+        Assert.assertEquals(StringFormatMessages.MESSAGES.repeat("value1"), String.format(foundFormat, "value1"));
+
+        foundFormat = properties.getProperty("twoMixedIndexes");
+        test("Second %2$s first %1$s", foundFormat, "second", "first");
+        Assert.assertEquals(StringFormatMessages.MESSAGES.twoMixedIndexes("second", "first"), String.format(foundFormat, "second", "first"));
+
+        foundFormat = properties.getProperty("threeMixedIndexes");
+        test("Third %3$s first %1$s second %2$s", foundFormat, 3, 1, 2);
+        Assert.assertEquals(StringFormatMessages.MESSAGES.threeMixedIndexes(3, 1, 2), String.format(foundFormat, 3, 1, 2));
+
+        foundFormat = properties.getProperty("fourMixedIndexes");
+        test("Third %3$s first %1$s second %2$s repeat second %2$s", foundFormat, 3, 1, 2);
+        Assert.assertEquals(StringFormatMessages.MESSAGES.fourMixedIndexes(3, 1, 2), String.format(foundFormat, 3, 1, 2));
+    }
+
+    private void test(final String expectedFormat, final String found, final Object... args) {
+        Assert.assertEquals(expectedFormat, found);
+        Assert.assertEquals(String.format(expectedFormat, args), String.format(found, args));
+    }
+
+    private static Properties resolveProperties(final Class<?> type) throws IOException {
+        final Path file = findFile(type);
+        final Properties properties = new Properties();
+        try (BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        }
+        return properties;
+    }
+    private static Path findFile(final Class<?> type) {
+        final String filePath = type.getName().replace('.', File.separatorChar) + ".i18n.properties";
+        Assert.assertNotNull("Could not find the test.skeleton.file.path", DIR);
+        final Path file = Paths.get(DIR, filePath);
+        Assert.assertTrue(String.format("File %s was not found.", file), Files.exists(file));
+        return file;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/StringFormatMessages.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/StringFormatMessages.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.logging.processor.generated;
+
+import java.util.Date;
+
+import org.jboss.logging.Messages;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@MessageBundle(projectCode = "TEST")
+public interface StringFormatMessages {
+
+    StringFormatMessages MESSAGES = Messages.getBundle(StringFormatMessages.class);
+
+    @Message("String %s integer %d")
+    String stringInt(String s, int i);
+
+    @Message("Duke's Birthday: %1$tm %<te,%<tY")
+    String dukesBirthday(Date date);
+
+    @Message("The error is %s, I repeat %1$s")
+    String repeat(String message);
+
+    @Message("Second %2$s first %s")
+    String twoMixedIndexes(String second, String first);
+
+    @Message("Third %3$s first %s second %s")
+    String threeMixedIndexes(int third, int first, int second);
+
+    @Message("Third %3$s first %s second %2$s repeat second %s")
+    String fourMixedIndexes(int third, int first, int second);
+}


### PR DESCRIPTION
…rmat pattern in the skeleton files. This should be helpful for translators to ensure the order is correct.

This can also be disabled with an annotation processor option.

https://issues.jboss.org/browse/LOGTOOL-143