### PR TITLE
[LOGTOOL-144] Make annotations accessible at runtime …

### DIFF
--- a/annotations/src/main/java/org/jboss/logging/annotations/BaseUrl.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/BaseUrl.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -41,7 +41,7 @@ import java.lang.annotation.Target;
  * @since 1.2
  */
 @Target(TYPE)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface BaseUrl {
 

--- a/annotations/src/main/java/org/jboss/logging/annotations/Cause.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Cause.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(PARAMETER)
 @Documented
 public @interface Cause {

--- a/annotations/src/main/java/org/jboss/logging/annotations/ConstructType.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/ConstructType.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  * @since 2.0.0
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(METHOD)
 @Documented
 public @interface ConstructType {

--- a/annotations/src/main/java/org/jboss/logging/annotations/Field.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Field.java
@@ -21,7 +21,7 @@ package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Repeatable;
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target({PARAMETER, METHOD})
 @Repeatable(Fields.class)
 @Documented

--- a/annotations/src/main/java/org/jboss/logging/annotations/Fields.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Fields.java
@@ -21,7 +21,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(METHOD)
 @Documented
 public @interface Fields {

--- a/annotations/src/main/java/org/jboss/logging/annotations/FormatWith.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/FormatWith.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 @Target(PARAMETER)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface FormatWith {
 

--- a/annotations/src/main/java/org/jboss/logging/annotations/LogMessage.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/LogMessage.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -34,7 +34,7 @@ import org.jboss.logging.Logger;
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(METHOD)
 @Documented
 public @interface LogMessage {

--- a/annotations/src/main/java/org/jboss/logging/annotations/LoggingClass.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/LoggingClass.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(PARAMETER)
 @Documented
 public @interface LoggingClass {

--- a/annotations/src/main/java/org/jboss/logging/annotations/Message.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Message.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 @Target(METHOD)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface Message {
 

--- a/annotations/src/main/java/org/jboss/logging/annotations/MessageBundle.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/MessageBundle.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -33,7 +33,7 @@ import java.util.Locale;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 @Target(TYPE)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface MessageBundle {
 

--- a/annotations/src/main/java/org/jboss/logging/annotations/MessageLogger.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/MessageLogger.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -34,7 +34,7 @@ import java.util.Locale;
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(TYPE)
 @Documented
 public @interface MessageLogger {

--- a/annotations/src/main/java/org/jboss/logging/annotations/Once.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Once.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @Target(METHOD)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface Once {
 }

--- a/annotations/src/main/java/org/jboss/logging/annotations/Param.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Param.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @Target(PARAMETER)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface Param {
 

--- a/annotations/src/main/java/org/jboss/logging/annotations/Pos.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Pos.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  * @since 1.1.0
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(PARAMETER)
 @Documented
 public @interface Pos {

--- a/annotations/src/main/java/org/jboss/logging/annotations/Producer.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Producer.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -70,7 +70,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @Target(PARAMETER)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface Producer {
 }

--- a/annotations/src/main/java/org/jboss/logging/annotations/Properties.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Properties.java
@@ -21,7 +21,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(METHOD)
 @Documented
 public @interface Properties {

--- a/annotations/src/main/java/org/jboss/logging/annotations/Property.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Property.java
@@ -22,7 +22,7 @@ package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Repeatable;
@@ -41,7 +41,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target({PARAMETER, METHOD})
 @Repeatable(Properties.class)
 @Documented

--- a/annotations/src/main/java/org/jboss/logging/annotations/ResolutionDoc.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/ResolutionDoc.java
@@ -21,7 +21,7 @@ package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -68,7 +68,7 @@ import java.lang.annotation.Target;
  * @since 1.2
  */
 @Target({METHOD, TYPE})
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface ResolutionDoc {
 

--- a/annotations/src/main/java/org/jboss/logging/annotations/Signature.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Signature.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -69,7 +69,7 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(METHOD)
 @Documented
 public @interface Signature {

--- a/annotations/src/main/java/org/jboss/logging/annotations/Suppressed.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Suppressed.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(PARAMETER)
 @Documented
 public @interface Suppressed {

--- a/annotations/src/main/java/org/jboss/logging/annotations/Transform.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/Transform.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  * @since 1.1.0
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target(PARAMETER)
 @Documented
 public @interface Transform {

--- a/annotations/src/main/java/org/jboss/logging/annotations/ValidIdRange.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/ValidIdRange.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -49,7 +49,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @Target(TYPE)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface ValidIdRange {
 

--- a/annotations/src/main/java/org/jboss/logging/annotations/ValidIdRanges.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/ValidIdRanges.java
@@ -20,7 +20,7 @@
 package org.jboss.logging.annotations;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @Target(TYPE)
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Documented
 public @interface ValidIdRanges {
 


### PR DESCRIPTION
(ie runtime retention).

For the sake of consistency, all annotations have been passed to runtime retention.
See https://issues.redhat.com/browse/LOGTOOL-144 for more context.