### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/ClassModelHelper.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/ClassModelHelper.java
@@ -52,7 +52,11 @@ public final class ClassModelHelper {
      */
     static String generatedDateValue() {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-        return sdf.format(new Date());
+        Date d;
+        d = System.getenv("SOURCE_DATE_EPOCH") == null ?
+          new Date() :
+          new Date(1000 * Long.parseLong(System.getenv("SOURCE_DATE_EPOCH")));
+        return sdf.format(d);
     }
 
     /**


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This patch allows openSUSE's `resteasy` package to build more reproducibly.

Without this patch, there were such diffs:

```diff
+++ /usr/share/javadoc/resteasy/org/jboss/resteasy/client/jaxrs/i18n/LogMessages_$logger.html       2020-05-09 00:52:40.125364506 +0000
@@ -143,7 +143,7 @@
 </dl>
 <hr>
 <pre><a href="https://docs.oracle.com/javase/7/docs/api/javax/annotation/Generated.html?is-external=true" title="class or interface in javax.annotation" class="externalLink">@Generated</a>(<a href="https://docs.oracle.com/javase/7/docs/api/javax/annotation/Generated.html?is-external=true#href_anchor" title="class or interface in javax.annotation" class="externalLink">value</a>="org.jboss.logging.processor.generator.model.MessageLoggerImplementor",
-           <a href="https://docs.oracle.com/javase/7/docs/api/javax/annotation/Generated.html?is-external=true#href_anchor" title="class or interface in javax.annotation" class="externalLink">date</a>="2020-05-09T00:51:48+0000")
+           <a href="https://docs.oracle.com/javase/7/docs/api/javax/annotation/Generated.html?is-external=true#href_anchor" title="class or interface in javax.annotation" class="externalLink">date</a>="2020-05-09T00:53:02+0000")
```

This PR was done while working on reproducible builds for openSUSE.