### PR TITLE
[LOGTOOL-146] Add an attribute the LogMessage annotation which allows…

### DIFF
--- a/annotations/src/main/java/org/jboss/logging/annotations/LogMessage.java
+++ b/annotations/src/main/java/org/jboss/logging/annotations/LogMessage.java
@@ -29,10 +29,11 @@ import java.lang.annotation.Target;
 import org.jboss.logging.Logger;
 
 /**
- * A typed logger method.  Indicates that this method will log the associated {@link Message} to the logger system, as
+ * A typed logger method. Indicates that this method will log the associated {@link Message} to the logger system, as
  * opposed to being a simple message lookup.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @Retention(CLASS)
 @Target(METHOD)
@@ -52,4 +53,23 @@ public @interface LogMessage {
      * @return the logging class name
      */
     Class<?> loggingClass() default Void.class;
+
+    /**
+     * Indicates before the message is logged the {@linkplain Thread#currentThread() current threads}
+     * {@linkplain Thread#setContextClassLoader(ClassLoader) context class loader} is set to the the class loader from
+     * this type.
+     * <p>
+     * Note that special permissions may be required if running under a {@linkplain SecurityManager security manager}.
+     * </p>
+     * <p>
+     * It is suggested this not be used on methods which are invoked frequently as there is overhead to this.
+     * </p>
+     *
+     * @return {@code true} if the current threads context loader should be used for the log call
+     *
+     * @see Thread#getContextClassLoader()
+     * @see Thread#setContextClassLoader(ClassLoader)
+     * @since 2.3.0
+     */
+    boolean useThreadContext() default false;
 }

--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/ImplementationClassModel.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/ImplementationClassModel.java
@@ -352,17 +352,16 @@ abstract class ImplementationClassModel extends ClassModel {
     private String getUniqueName(final List<String> parameterNames, final Parameter parameter, final String suffix) {
         String result = (suffix == null ? parameter.name() : parameter.name().concat(suffix));
         if (parameterNames.contains(result)) {
-            return getUniqueName(parameterNames, new StringBuilder(result), 0);
+            return getUniqueName(parameterNames, result, 0);
         }
         return result;
     }
 
-    private String getUniqueName(final List<String> parameterNames, final StringBuilder sb, final int index) {
-        String result = sb.append(index).toString();
-        if (parameterNames.contains(result)) {
-            return getUniqueName(parameterNames, sb, index + 1);
+    protected String getUniqueName(final List<String> parameterNames, final String name, final int index) {
+        if (parameterNames.contains(name)) {
+            return getUniqueName(parameterNames, name + index, index + 1);
         }
-        return result;
+        return name;
     }
 
     private void addMethodTypeParameters(final JMethodDef method, final TypeMirror type) {

--- a/processor/src/test/java/org/jboss/logging/processor/generated/DefaultLogger.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/DefaultLogger.java
@@ -73,11 +73,11 @@ interface DefaultLogger extends BasicLogger {
     @Message(id = 102, format = Format.NO_FORMAT, value = TEST_MSG)
     void noFormat();
 
-    @LogMessage(level = Level.INFO)
+    @LogMessage(level = Level.INFO, useThreadContext = true)
     @Message(id = 103, format = Format.NO_FORMAT, value = TEST_MSG)
     void noFormatWithCause(@Cause Throwable cause);
 
-    @LogMessage(level = Level.INFO)
+    @LogMessage(level = Level.INFO, useThreadContext = true)
     @Message(id = 104, value = "Test Message: %s")
     void formatWith(@FormatWith(CustomFormatter.class) String msg);
 

--- a/processor/src/test/java/org/jboss/logging/processor/generated/LogOnceLogger.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/LogOnceLogger.java
@@ -49,7 +49,7 @@ public interface LogOnceLogger {
     @Message("'%s' has been deprecated.")
     void deprecated(String key);
 
-    @LogMessage(level = Level.WARN)
+    @LogMessage(level = Level.WARN, useThreadContext = true)
     @Once
     @Message("'%s' has been deprecated. Please use '%s'.")
     void deprecated(String key, String replacement);

--- a/processor/src/test/java/org/jboss/logging/processor/generated/TransformLogger.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/TransformLogger.java
@@ -54,7 +54,7 @@ public interface TransformLogger {
     @Message(HASH_CODE_MSG)
     void logClassHashCode(@Transform({TransformType.GET_CLASS, TransformType.HASH_CODE}) String s);
 
-    @LogMessage
+    @LogMessage(useThreadContext = true)
     void logClassHashCode(@Transform({TransformType.GET_CLASS, TransformType.HASH_CODE}) Collection<String> c);
 
     @LogMessage


### PR DESCRIPTION
… the generated code to set and reset the current threads context class loader during a log statement.

https://issues.redhat.com/browse/LOGTOOL-146

An example message gets generated as:
```java
@Override
public final void noFormatWithCause(final Throwable cause) {
    final ClassLoader currentTccl = Thread.currentThread().getContextClassLoader();
    try {
        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
        super.log.log(FQCN, INFO, noFormatWithCause$str(), null, cause);
    } finally {
        Thread.currentThread().setContextClassLoader(currentTccl);
    }
}
```