### PR TITLE
[LOGTOOL-134] Use the @Cause argument type when determining whether o…

### DIFF
--- a/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessages.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessages.java
@@ -143,6 +143,9 @@ public interface ValidMessages {
     @Message(TEST_MSG)
     <T extends RuntimeException> Supplier<T> throwableStringBiFunctionSupplier(@Producer BiFunction<String, Exception, T> function, @Cause Exception cause);
 
+    @Message(TEST_MSG)
+    UncheckedException wrapped(@Cause Throwable cause);
+
     @SuppressWarnings({"InstanceVariableMayNotBeInitialized", "unused"})
     class CustomException extends RuntimeException {
         public int value;
@@ -187,6 +190,17 @@ public interface ValidMessages {
     class StringOnlyException extends RuntimeException {
         public StringOnlyException(final String msg) {
             super(msg);
+        }
+    }
+
+    class UncheckedException extends RuntimeException {
+
+        public UncheckedException(final String msg) {
+            super(msg);
+        }
+
+        public UncheckedException(final Exception e) {
+            super(e);
         }
     }
 }

--- a/processor/src/test/java/org/jboss/logging/processor/generated/tests/MessagesTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/tests/MessagesTest.java
@@ -69,6 +69,15 @@ public class MessagesTest {
     }
 
     @Test
+    public void testCauseInitialized() {
+        final IOException exception = new IOException("Write failure");
+        final ValidMessages.UncheckedException wrapped = ValidMessages.MESSAGES.wrapped(exception);
+        Assertions.assertEquals(FORMATTED_TEST_MSG, wrapped.getMessage());
+        Assertions.assertTrue((wrapped.getCause() instanceof IOException),
+                "Expected the cause to be an IOException but was " + wrapped.getCause());
+    }
+
+    @Test
     public void testSuppressed() {
         final IllegalArgumentException e1 = new IllegalArgumentException("First exception");
         final IllegalStateException e2 = new IllegalStateException("Second exception");


### PR DESCRIPTION
…r not there is a valid constructor. If the type argument and the constructor argument are not assignable, but there is another valid constructor use the Throwable.initCause() for it.

https://issues.redhat.com/browse/LOGTOOL-134