### PR TITLE
Change how the default class translation files path is constructed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
         <version.org.jboss.logmanager>3.0.4.Final</version.org.jboss.logmanager>
         <verion.org.jboss.forge.roaster>2.22.3.Final</verion.org.jboss.forge.roaster>
         <version.org.junit>5.10.2</version.org.junit>
+
+        <!-- Eclipse compiler properties -->
+        <version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>2.15.0</version.org.codehaus.plexus.plexus-compiler.compiler-eclipse>
+        <version.org.eclipse.jdt.ecj>3.37.0</version.org.eclipse.jdt.ecj>
     </properties>
 
     <licenses>
@@ -180,6 +184,50 @@
                         </executions>
                     </plugin>
                 </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>compiler-eclipse</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default-testCompile</id>
+                                    <configuration>
+                                        <compilerId>eclipse</compilerId>
+                                        <source>${maven.compiler.release}</source>
+                                        <target>${maven.compiler.release}</target>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.codehaus.plexus</groupId>
+                                    <artifactId>plexus-compiler-api</artifactId>
+                                    <version>${version.org.codehaus.plexus.plexus-compiler.compiler-eclipse}</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.codehaus.plexus</groupId>
+                                    <artifactId>plexus-compiler-manager</artifactId>
+                                    <version>${version.org.codehaus.plexus.plexus-compiler.compiler-eclipse}</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.codehaus.plexus</groupId>
+                                    <artifactId>plexus-compiler-eclipse</artifactId>
+                                    <version>${version.org.codehaus.plexus.plexus-compiler.compiler-eclipse}</version>
+                                </dependency>
+                                <dependency>
+                                    <groupId>org.eclipse.jdt</groupId>
+                                    <artifactId>ecj</artifactId>
+                                    <version>${version.org.eclipse.jdt.ecj}</version>
+                                </dependency>
+                            </dependencies>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
             </build>
         </profile>
     </profiles>

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstants.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstants.java
@@ -39,272 +39,113 @@ public interface MethodMessageConstants {
 
     @Message(TEST_MSG)
     @Property(name = "value", intValue = Integer.MAX_VALUE)
-    IntTypeException intProperty();
+    MethodMessageConstantsIntTypeException intProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", longValue = Long.MAX_VALUE)
-    LongTypeException longProperty();
+    MethodMessageConstantsLongTypeException longProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", shortValue = Short.MAX_VALUE)
-    ShortTypeException shortProperty();
+    MethodMessageConstantsShortTypeException shortProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", doubleValue = Double.MAX_VALUE)
-    DoubleTypeException douleProperty();
+    MethodMessageConstantsDoubleTypeException douleProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", floatValue = Float.MAX_VALUE)
-    FloatTypeException floatProperty();
+    MethodMessageConstantsFloatTypeException floatProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", booleanValue = true)
-    BooleanTypeException booleanProperty();
+    MethodMessageConstantsBooleanTypeException booleanProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", charValue = testChar)
-    CharTypeException charProperty();
+    MethodMessageConstantsCharTypeException charProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", byteValue = (byte) 'x')
-    ByteTypeException byteProperty();
+    MethodMessageConstantsByteTypeException byteProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", classValue = ValueType.class)
-    ClassTypeException classProperty();
+    MethodMessageConstantsClassTypeException classProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", stringValue = stringTest)
-    StringTypeException stringProperty();
+    MethodMessageConstantsStringTypeException stringProperty();
 
     @Message(TEST_MSG)
     @Property(name = "value", stringValue = stringTest)
     @Property(name = "type", classValue = String.class)
-    TypeException repeatableProperty();
+    MethodMessageConstantsTypeException repeatableProperty();
 
     @Message(TEST_MSG)
     @Properties({
             @Property(name = "value", stringValue = stringTest),
             @Property(name = "type", classValue = String.class)
     })
-    TypeException multiProperty();
+    MethodMessageConstantsTypeException multiProperty();
 
     // Fields
 
     @Message(TEST_MSG)
     @Field(name = "value", intValue = Integer.MAX_VALUE)
-    IntTypeException intField();
+    MethodMessageConstantsIntTypeException intField();
 
     @Message(TEST_MSG)
     @Field(name = "value", longValue = Long.MAX_VALUE)
-    LongTypeException longField();
+    MethodMessageConstantsLongTypeException longField();
 
     @Message(TEST_MSG)
     @Field(name = "value", shortValue = Short.MAX_VALUE)
-    ShortTypeException shortField();
+    MethodMessageConstantsShortTypeException shortField();
 
     @Message(TEST_MSG)
     @Field(name = "value", doubleValue = Double.MAX_VALUE)
-    DoubleTypeException douleField();
+    MethodMessageConstantsDoubleTypeException douleField();
 
     @Message(TEST_MSG)
     @Field(name = "value", floatValue = Float.MAX_VALUE)
-    FloatTypeException floatField();
+    MethodMessageConstantsFloatTypeException floatField();
 
     @Message(TEST_MSG)
     @Field(name = "value", booleanValue = true)
-    BooleanTypeException booleanField();
+    MethodMessageConstantsBooleanTypeException booleanField();
 
     char testChar = 'c';
 
     @Message(TEST_MSG)
     @Field(name = "value", charValue = testChar)
-    CharTypeException charField();
+    MethodMessageConstantsCharTypeException charField();
 
     @Message(TEST_MSG)
     @Field(name = "value", byteValue = (byte) 'x')
-    ByteTypeException byteField();
+    MethodMessageConstantsByteTypeException byteField();
 
     @Message(TEST_MSG)
     @Field(name = "value", classValue = ValueType.class)
-    ClassTypeException classField();
+    MethodMessageConstantsClassTypeException classField();
 
     String stringTest = "test";
 
     @Message(TEST_MSG)
     @Field(name = "value", stringValue = stringTest)
-    StringTypeException stringField();
+    MethodMessageConstantsStringTypeException stringField();
 
     @Message(TEST_MSG)
     @Field(name = "value", stringValue = stringTest)
     @Field(name = "type", classValue = String.class)
-    TypeException repeatableField();
+    MethodMessageConstantsTypeException repeatableField();
 
     @Message(TEST_MSG)
     @Fields({
             @Field(name = "value", stringValue = stringTest),
             @Field(name = "type", classValue = String.class)
     })
-    TypeException multiField();
-
-    @SuppressWarnings({ "InstanceVariableMayNotBeInitialized", "unused" })
-    class TypeException extends RuntimeException {
-        public Class<?> type;
-        public Object value;
-
-        public TypeException() {
-        }
-
-        public TypeException(final String msg) {
-            super(msg);
-        }
-
-        public TypeException(final Throwable t) {
-            super(t);
-        }
-
-        public TypeException(final String msg, final Throwable t) {
-            super(msg, t);
-        }
-
-        public void setValue(final Object value) {
-            this.value = value;
-        }
-
-        public void setType(final Class<?> type) {
-            this.type = type;
-        }
-    }
-
-    class IntTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public int value;
-
-        public IntTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final Integer value) {
-            this.value = value;
-        }
-    }
-
-    class LongTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public long value;
-
-        public LongTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final long value) {
-            this.value = value;
-        }
-    }
-
-    class ShortTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public short value;
-
-        public ShortTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final short value) {
-            this.value = value;
-        }
-    }
-
-    class FloatTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public float value;
-
-        public FloatTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final float value) {
-            this.value = value;
-        }
-    }
-
-    class DoubleTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public double value;
-
-        public DoubleTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final double value) {
-            this.value = value;
-        }
-    }
-
-    class BooleanTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public boolean value;
-
-        public BooleanTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final boolean value) {
-            this.value = value;
-        }
-    }
-
-    class ByteTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public byte value;
-
-        public ByteTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final byte value) {
-            this.value = value;
-        }
-    }
-
-    class CharTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public char value;
-
-        public CharTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final char value) {
-            this.value = value;
-        }
-    }
-
-    class ClassTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public Class<?> value;
-
-        public ClassTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final Class<?> value) {
-            this.value = value;
-        }
-    }
-
-    class StringTypeException extends RuntimeException {
-        @SuppressWarnings("InstanceVariableMayNotBeInitialized")
-        public String value;
-
-        public StringTypeException(final String message) {
-            super(message);
-        }
-
-        public void setValue(final String value) {
-            this.value = value;
-        }
-    }
+    MethodMessageConstantsTypeException multiField();
 
     class ValueType {
     }

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsBooleanTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsBooleanTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsBooleanTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public boolean value;
+
+    public MethodMessageConstantsBooleanTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final boolean value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsByteTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsByteTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsByteTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public byte value;
+
+    public MethodMessageConstantsByteTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final byte value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsCharTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsCharTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsCharTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public char value;
+
+    public MethodMessageConstantsCharTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final char value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsClassTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsClassTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsClassTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public Class<?> value;
+
+    public MethodMessageConstantsClassTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final Class<?> value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsDoubleTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsDoubleTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsDoubleTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public double value;
+
+    public MethodMessageConstantsDoubleTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final double value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsFloatTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsFloatTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsFloatTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public float value;
+
+    public MethodMessageConstantsFloatTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final float value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsIntTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsIntTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsIntTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public int value;
+
+    public MethodMessageConstantsIntTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final Integer value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsLongTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsLongTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsLongTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public long value;
+
+    public MethodMessageConstantsLongTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final long value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsShortTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsShortTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsShortTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public short value;
+
+    public MethodMessageConstantsShortTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final short value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsStringTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsStringTypeException.java
@@ -1,0 +1,14 @@
+package org.jboss.logging.processor.generated;
+
+public class MethodMessageConstantsStringTypeException extends RuntimeException {
+    @SuppressWarnings("InstanceVariableMayNotBeInitialized")
+    public String value;
+
+    public MethodMessageConstantsStringTypeException(final String message) {
+        super(message);
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsTypeException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/MethodMessageConstantsTypeException.java
@@ -1,0 +1,30 @@
+package org.jboss.logging.processor.generated;
+
+@SuppressWarnings({ "InstanceVariableMayNotBeInitialized", "unused" })
+public class MethodMessageConstantsTypeException extends RuntimeException {
+    public Class<?> type;
+    public Object value;
+
+    public MethodMessageConstantsTypeException() {
+    }
+
+    public MethodMessageConstantsTypeException(final String msg) {
+        super(msg);
+    }
+
+    public MethodMessageConstantsTypeException(final Throwable t) {
+        super(t);
+    }
+
+    public MethodMessageConstantsTypeException(final String msg, final Throwable t) {
+        super(msg, t);
+    }
+
+    public void setValue(final Object value) {
+        this.value = value;
+    }
+
+    public void setType(final Class<?> type) {
+        this.type = type;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/SignatureMessages.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/SignatureMessages.java
@@ -19,16 +19,12 @@
 
 package org.jboss.logging.processor.generated;
 
-import static org.jboss.logging.processor.util.Objects.areEqual;
-
 import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 import org.jboss.logging.annotations.Param;
 import org.jboss.logging.annotations.Signature;
-import org.jboss.logging.processor.util.Objects;
-import org.jboss.logging.processor.util.Objects.HashCodeBuilder;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -40,211 +36,24 @@ public interface SignatureMessages {
     SignatureMessages MESSAGES = Messages.getBundle(SignatureMessages.class);
 
     @Message(TEST_MSG)
-    RedirectException redirect(@Param int responseCode, @Param String location);
+    SignatureMessagesRedirectException redirect(@Param int responseCode, @Param String location);
 
-    RedirectException redirect(@Cause Throwable cause, @Param int responseCode, @Param String location);
+    SignatureMessagesRedirectException redirect(@Cause Throwable cause, @Param int responseCode, @Param String location);
 
     @Signature({ String.class, String.class })
-    RedirectException redirect(@Cause Throwable cause, @Param String location);
+    SignatureMessagesRedirectException redirect(@Cause Throwable cause, @Param String location);
 
     @Message(TEST_MSG)
-    TestException test();
+    SignatureMessagesTestException test();
 
-    TestException test(@Cause Throwable cause);
+    SignatureMessagesTestException test(@Cause Throwable cause);
 
     @Message(TEST_MSG)
-    InvalidTextException invalidText(@Param String text);
+    SignatureMessagesInvalidTextException invalidText(@Param String text);
 
-    InvalidTextException invalidText(@Cause Throwable cause, @Param String text);
+    SignatureMessagesInvalidTextException invalidText(@Cause Throwable cause, @Param String text);
 
     @Signature(causeIndex = 1, messageIndex = 3, value = { int.class, Throwable.class, String.class, String.class })
-    InvalidTextException invalidText(@Param int position, @Cause Throwable cause, @Param String text);
+    SignatureMessagesInvalidTextException invalidText(@Param int position, @Cause Throwable cause, @Param String text);
 
-    @SuppressWarnings("unused")
-    class RedirectException extends RuntimeException {
-        final int statusCode;
-        final String location;
-
-        public RedirectException(final String msg, final Throwable cause, final int statusCode, final String location) {
-            super(msg, cause);
-            this.statusCode = statusCode;
-            this.location = location;
-        }
-
-        public RedirectException(final int statusCode, final String location) {
-            throw new IllegalStateException("Should never be chosen");
-        }
-
-        public RedirectException(final Throwable cause, final int statusCode, final String location) {
-            throw new IllegalStateException("Should never be chosen");
-        }
-
-        public RedirectException(final String msg, final int statusCode, final String location) {
-            super(msg);
-            this.statusCode = statusCode;
-            this.location = location;
-        }
-
-        public RedirectException(final String msg, final String location) {
-            super(msg);
-            this.statusCode = 301;
-            this.location = location;
-        }
-
-        @Override
-        public int hashCode() {
-            return HashCodeBuilder.builder()
-                    .add(statusCode)
-                    .add(location)
-                    .add(getMessage())
-                    .add(getCause())
-                    .toHashCode();
-        }
-
-        @Override
-        public boolean equals(final Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (!(obj instanceof RedirectException)) {
-                return false;
-            }
-            final RedirectException other = (RedirectException) obj;
-            return areEqual(statusCode, other.statusCode) &&
-                    areEqual(location, other.location) &&
-                    areEqual(getMessage(), other.getMessage()) &&
-                    areEqual(getCause(), other.getCause());
-        }
-
-        @Override
-        public String toString() {
-            return Objects.ToStringBuilder.of(this)
-                    .add("statusCode", statusCode)
-                    .add("location", location)
-                    .add("message", getMessage())
-                    .add("cause", getCause())
-                    .toString();
-        }
-    }
-
-    @SuppressWarnings("unused")
-    class TestException extends RuntimeException {
-
-        public TestException(final String message) {
-            super(message);
-        }
-
-        public TestException(final String message, final Throwable cause) {
-            super(message, cause);
-        }
-
-        public TestException(final Throwable cause) {
-            throw new IllegalStateException("Should never be chosen");
-        }
-
-        @Override
-        public int hashCode() {
-            return HashCodeBuilder.builder()
-                    .add(getMessage())
-                    .add(getCause())
-                    .toHashCode();
-        }
-
-        @Override
-        public boolean equals(final Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (!(obj instanceof TestException)) {
-                return false;
-            }
-            final TestException other = (TestException) obj;
-            return areEqual(getMessage(), other.getMessage()) &&
-                    areEqual(getCause(), other.getCause());
-        }
-
-        @Override
-        public String toString() {
-            return Objects.ToStringBuilder.of(this)
-                    .add("message", getMessage())
-                    .add("cause", getCause())
-                    .toString();
-        }
-    }
-
-    @SuppressWarnings("unused")
-    class InvalidTextException extends RuntimeException {
-        final String value;
-        final int position;
-
-        public InvalidTextException(final String value) {
-            this.value = value;
-            position = -1;
-        }
-
-        public InvalidTextException(final String msg, final String value) {
-            super(msg);
-            this.value = value;
-            position = -1;
-        }
-
-        public InvalidTextException(final Throwable cause) {
-            throw new IllegalStateException("Should never be chosen");
-        }
-
-        public InvalidTextException(final String message, final Throwable cause) {
-            throw new IllegalStateException("Should never be chosen");
-        }
-
-        public InvalidTextException(final String msg, final Throwable cause, final String value) {
-            super(msg, cause);
-            this.value = value;
-            position = -1;
-        }
-
-        public InvalidTextException(final int position, final Throwable cause, final String value, final String msg) {
-            super(msg, cause);
-            this.value = value;
-            this.position = position;
-        }
-
-        public InvalidTextException(final Integer position, final Throwable cause, final String value, final String msg) {
-            throw new IllegalStateException("Should never be chosen");
-        }
-
-        @Override
-        public int hashCode() {
-            return HashCodeBuilder.builder()
-                    .add(value)
-                    .add(position)
-                    .add(getMessage())
-                    .add(getCause())
-                    .toHashCode();
-        }
-
-        @Override
-        public boolean equals(final Object obj) {
-            if (obj == this) {
-                return true;
-            }
-            if (!(obj instanceof InvalidTextException)) {
-                return false;
-            }
-            final InvalidTextException other = (InvalidTextException) obj;
-            return areEqual(value, other.value) &&
-                    areEqual(position, other.position) &&
-                    areEqual(getMessage(), other.getMessage()) &&
-                    areEqual(getCause(), other.getCause());
-        }
-
-        @Override
-        public String toString() {
-            return Objects.ToStringBuilder.of(this)
-                    .add("value", value)
-                    .add("position", position)
-                    .add("message", getMessage())
-                    .add("cause", getCause())
-                    .toString();
-        }
-    }
 }

--- a/processor/src/test/java/org/jboss/logging/processor/generated/SignatureMessagesInvalidTextException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/SignatureMessagesInvalidTextException.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.processor.generated;
+
+import static org.jboss.logging.processor.util.Objects.areEqual;
+
+import org.jboss.logging.processor.util.Objects;
+
+@SuppressWarnings("unused")
+public class SignatureMessagesInvalidTextException extends RuntimeException {
+    final String value;
+    final int position;
+
+    public SignatureMessagesInvalidTextException(final String value) {
+        this.value = value;
+        position = -1;
+    }
+
+    public SignatureMessagesInvalidTextException(final String msg, final String value) {
+        super(msg);
+        this.value = value;
+        position = -1;
+    }
+
+    public SignatureMessagesInvalidTextException(final Throwable cause) {
+        throw new IllegalStateException("Should never be chosen");
+    }
+
+    public SignatureMessagesInvalidTextException(final String message, final Throwable cause) {
+        throw new IllegalStateException("Should never be chosen");
+    }
+
+    public SignatureMessagesInvalidTextException(final String msg, final Throwable cause, final String value) {
+        super(msg, cause);
+        this.value = value;
+        position = -1;
+    }
+
+    public SignatureMessagesInvalidTextException(final int position, final Throwable cause, final String value,
+            final String msg) {
+        super(msg, cause);
+        this.value = value;
+        this.position = position;
+    }
+
+    public SignatureMessagesInvalidTextException(final Integer position, final Throwable cause, final String value,
+            final String msg) {
+        throw new IllegalStateException("Should never be chosen");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.HashCodeBuilder.builder()
+                .add(value)
+                .add(position)
+                .add(getMessage())
+                .add(getCause())
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof SignatureMessagesInvalidTextException)) {
+            return false;
+        }
+        final SignatureMessagesInvalidTextException other = (SignatureMessagesInvalidTextException) obj;
+        return areEqual(value, other.value) &&
+                areEqual(position, other.position) &&
+                areEqual(getMessage(), other.getMessage()) &&
+                areEqual(getCause(), other.getCause());
+    }
+
+    @Override
+    public String toString() {
+        return Objects.ToStringBuilder.of(this)
+                .add("value", value)
+                .add("position", position)
+                .add("message", getMessage())
+                .add("cause", getCause())
+                .toString();
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/SignatureMessagesRedirectException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/SignatureMessagesRedirectException.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.processor.generated;
+
+import static org.jboss.logging.processor.util.Objects.areEqual;
+
+import org.jboss.logging.processor.util.Objects;
+
+@SuppressWarnings("unused")
+public class SignatureMessagesRedirectException extends RuntimeException {
+    final int statusCode;
+    final String location;
+
+    public SignatureMessagesRedirectException(final String msg, final Throwable cause, final int statusCode,
+            final String location) {
+        super(msg, cause);
+        this.statusCode = statusCode;
+        this.location = location;
+    }
+
+    public SignatureMessagesRedirectException(final int statusCode, final String location) {
+        throw new IllegalStateException("Should never be chosen");
+    }
+
+    public SignatureMessagesRedirectException(final Throwable cause, final int statusCode, final String location) {
+        throw new IllegalStateException("Should never be chosen");
+    }
+
+    public SignatureMessagesRedirectException(final String msg, final int statusCode, final String location) {
+        super(msg);
+        this.statusCode = statusCode;
+        this.location = location;
+    }
+
+    public SignatureMessagesRedirectException(final String msg, final String location) {
+        super(msg);
+        this.statusCode = 301;
+        this.location = location;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.HashCodeBuilder.builder()
+                .add(statusCode)
+                .add(location)
+                .add(getMessage())
+                .add(getCause())
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof SignatureMessagesRedirectException)) {
+            return false;
+        }
+        final SignatureMessagesRedirectException other = (SignatureMessagesRedirectException) obj;
+        return areEqual(statusCode, other.statusCode) &&
+                areEqual(location, other.location) &&
+                areEqual(getMessage(), other.getMessage()) &&
+                areEqual(getCause(), other.getCause());
+    }
+
+    @Override
+    public String toString() {
+        return Objects.ToStringBuilder.of(this)
+                .add("statusCode", statusCode)
+                .add("location", location)
+                .add("message", getMessage())
+                .add("cause", getCause())
+                .toString();
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/SignatureMessagesTestException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/SignatureMessagesTestException.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.processor.generated;
+
+import static org.jboss.logging.processor.util.Objects.areEqual;
+
+import org.jboss.logging.processor.util.Objects;
+
+@SuppressWarnings("unused")
+public class SignatureMessagesTestException extends RuntimeException {
+
+    public SignatureMessagesTestException(final String message) {
+        super(message);
+    }
+
+    public SignatureMessagesTestException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public SignatureMessagesTestException(final Throwable cause) {
+        throw new IllegalStateException("Should never be chosen");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.HashCodeBuilder.builder()
+                .add(getMessage())
+                .add(getCause())
+                .toHashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof SignatureMessagesTestException)) {
+            return false;
+        }
+        final SignatureMessagesTestException other = (SignatureMessagesTestException) obj;
+        return areEqual(getMessage(), other.getMessage()) &&
+                areEqual(getCause(), other.getCause());
+    }
+
+    @Override
+    public String toString() {
+        return Objects.ToStringBuilder.of(this)
+                .add("message", getMessage())
+                .add("cause", getCause())
+                .toString();
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessages.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessages.java
@@ -63,19 +63,19 @@ public interface ValidMessages {
     RuntimeException noFormatException(@Cause Throwable cause);
 
     @Message(TEST_MSG)
-    CustomException fieldMessage(@Field(name = "value") int value);
+    ValidMessagesCustomException fieldMessage(@Field(name = "value") int value);
 
     @Message(TEST_MSG)
-    CustomException paramMessage(@Param int value);
+    ValidMessagesCustomException paramMessage(@Param int value);
 
     @Message(TEST_MSG)
-    CustomException propertyMessage(@Property int value);
+    ValidMessagesCustomException propertyMessage(@Property int value);
 
     @Message(TEST_MSG)
-    LoggingException loggingException(@Cause Exception e);
+    ValidMessagesLoggingException loggingException(@Cause Exception e);
 
     @Message(TEST_MSG)
-    StringOnlyException stringOnlyException(@Cause Exception e);
+    ValidMessagesStringOnlyException stringOnlyException(@Cause Exception e);
 
     @ConstructType(IllegalArgumentException.class)
     @Message("Invalid user id or password")
@@ -113,10 +113,10 @@ public interface ValidMessages {
     Supplier<RuntimeException> testSupplierRuntimeException();
 
     @Message(TEST_MSG)
-    Supplier<CustomException> fieldMessageSupplier(@Field(name = "value") int value);
+    Supplier<ValidMessagesCustomException> fieldMessageSupplier(@Field(name = "value") int value);
 
     @Message(TEST_MSG)
-    Supplier<CustomException> propertyMessageSupplier(@Property int value);
+    Supplier<ValidMessagesCustomException> propertyMessageSupplier(@Property int value);
 
     @ConstructType(IllegalArgumentException.class)
     @Message("Invalid user id or password")
@@ -137,14 +137,16 @@ public interface ValidMessages {
     <T extends RuntimeException> Supplier<T> supplierFunction(@Producer Function<String, T> function);
 
     @Message(TEST_MSG)
-    <T extends CustomException> T fieldMessageFunction(@Producer Function<String, T> function,
+    <T extends ValidMessagesCustomException> T fieldMessageFunction(@Producer Function<String, T> function,
             @Field(name = "value") int value);
 
     @Message(TEST_MSG)
-    <T extends CustomException> T propertyMessageFunction(@Producer Function<String, T> function, @Property int value);
+    <T extends ValidMessagesCustomException> T propertyMessageFunction(@Producer Function<String, T> function,
+            @Property int value);
 
     @Message(TEST_MSG)
-    LoggingException throwableStringBiFunction(@Producer BiFunction<Exception, String, LoggingException> function,
+    ValidMessagesLoggingException throwableStringBiFunction(
+            @Producer BiFunction<Exception, String, ValidMessagesLoggingException> function,
             @Cause Exception cause);
 
     @Message(TEST_MSG)
@@ -152,7 +154,7 @@ public interface ValidMessages {
             @Producer BiFunction<String, Exception, T> function, @Cause Exception cause);
 
     @Message(TEST_MSG)
-    UncheckedException wrapped(@Cause Throwable cause);
+    ValidMessagesUncheckedException wrapped(@Cause Throwable cause);
 
     @Message("Binding to %s failed: %s")
     IOException bindFailed(SocketAddress address,
@@ -166,61 +168,4 @@ public interface ValidMessages {
     @Signature(value = { String.class, IOException.class }, causeIndex = 1)
     UncheckedIOException uncheckedIO(@Cause @TransformException(copyStackTrace = false) IOException toCopy);
 
-    @SuppressWarnings({ "InstanceVariableMayNotBeInitialized", "unused" })
-    class CustomException extends RuntimeException {
-        public int value;
-
-        public CustomException() {
-        }
-
-        public CustomException(final int value, final String msg) {
-            super(msg);
-            this.value = value;
-        }
-
-        public CustomException(final String msg) {
-            super(msg);
-        }
-
-        public CustomException(final Throwable t) {
-            super(t);
-        }
-
-        public CustomException(final String msg, final Throwable t) {
-            super(msg, t);
-        }
-
-        public void setValue(final int value) {
-            this.value = value;
-        }
-    }
-
-    @SuppressWarnings("unused")
-    class LoggingException extends RuntimeException {
-
-        public LoggingException(final Exception e) {
-            super(e);
-        }
-
-        public LoggingException(final Exception e, final String msg) {
-            super(msg, e);
-        }
-    }
-
-    class StringOnlyException extends RuntimeException {
-        public StringOnlyException(final String msg) {
-            super(msg);
-        }
-    }
-
-    class UncheckedException extends RuntimeException {
-
-        public UncheckedException(final String msg) {
-            super(msg);
-        }
-
-        public UncheckedException(final Exception e) {
-            super(e);
-        }
-    }
 }

--- a/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessagesCustomException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessagesCustomException.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.logging.processor.generated;
+
+@SuppressWarnings({ "InstanceVariableMayNotBeInitialized", "unused" })
+public class ValidMessagesCustomException extends RuntimeException {
+    public int value;
+
+    public ValidMessagesCustomException() {
+    }
+
+    public ValidMessagesCustomException(final int value, final String msg) {
+        super(msg);
+        this.value = value;
+    }
+
+    public ValidMessagesCustomException(final String msg) {
+        super(msg);
+    }
+
+    public ValidMessagesCustomException(final Throwable t) {
+        super(t);
+    }
+
+    public ValidMessagesCustomException(final String msg, final Throwable t) {
+        super(msg, t);
+    }
+
+    public void setValue(final int value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessagesLoggingException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessagesLoggingException.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.processor.generated;
+
+@SuppressWarnings("unused")
+public class ValidMessagesLoggingException extends RuntimeException {
+
+    public ValidMessagesLoggingException(final Exception e) {
+        super(e);
+    }
+
+    public ValidMessagesLoggingException(final Exception e, final String msg) {
+        super(msg, e);
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessagesStringOnlyException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessagesStringOnlyException.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.processor.generated;
+
+public class ValidMessagesStringOnlyException extends RuntimeException {
+    public ValidMessagesStringOnlyException(final String msg) {
+        super(msg);
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessagesUncheckedException.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/ValidMessagesUncheckedException.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging.processor.generated;
+
+public class ValidMessagesUncheckedException extends RuntimeException {
+
+    public ValidMessagesUncheckedException(final String msg) {
+        super(msg);
+    }
+
+    public ValidMessagesUncheckedException(final Exception e) {
+        super(e);
+    }
+}

--- a/processor/src/test/java/org/jboss/logging/processor/generated/tests/MessagesTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/tests/MessagesTest.java
@@ -30,10 +30,12 @@ import java.util.Arrays;
 import java.util.function.Supplier;
 
 import org.jboss.logging.processor.generated.MethodMessageConstants;
+import org.jboss.logging.processor.generated.MethodMessageConstantsTypeException;
 import org.jboss.logging.processor.generated.ValidMessages;
-import org.jboss.logging.processor.generated.ValidMessages.CustomException;
-import org.jboss.logging.processor.generated.ValidMessages.LoggingException;
-import org.jboss.logging.processor.generated.ValidMessages.StringOnlyException;
+import org.jboss.logging.processor.generated.ValidMessagesCustomException;
+import org.jboss.logging.processor.generated.ValidMessagesLoggingException;
+import org.jboss.logging.processor.generated.ValidMessagesStringOnlyException;
+import org.jboss.logging.processor.generated.ValidMessagesUncheckedException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +60,7 @@ public class MessagesTest {
         Assertions.assertEquals(value, ValidMessages.MESSAGES.paramMessage(value).value);
         Assertions.assertEquals(value, ValidMessages.MESSAGES.propertyMessage(value).value);
 
-        final StringOnlyException e = ValidMessages.MESSAGES.stringOnlyException(new RuntimeException());
+        final ValidMessagesStringOnlyException e = ValidMessages.MESSAGES.stringOnlyException(new RuntimeException());
         Assertions.assertEquals(FORMATTED_TEST_MSG, e.getMessage());
         Assertions.assertNotNull(e.getCause());
 
@@ -76,7 +78,7 @@ public class MessagesTest {
     @Test
     public void testCauseInitialized() {
         final IOException exception = new IOException("Write failure");
-        final ValidMessages.UncheckedException wrapped = ValidMessages.MESSAGES.wrapped(exception);
+        final ValidMessagesUncheckedException wrapped = ValidMessages.MESSAGES.wrapped(exception);
         Assertions.assertEquals(FORMATTED_TEST_MSG, wrapped.getMessage());
         Assertions.assertTrue((wrapped.getCause() instanceof IOException),
                 "Expected the cause to be an IOException but was " + wrapped.getCause());
@@ -126,7 +128,7 @@ public class MessagesTest {
         Assertions.assertEquals(Long.MAX_VALUE, MethodMessageConstants.MESSAGES.longProperty().value);
         Assertions.assertEquals(Short.MAX_VALUE, MethodMessageConstants.MESSAGES.shortProperty().value);
         Assertions.assertEquals(MethodMessageConstants.stringTest, MethodMessageConstants.MESSAGES.stringProperty().value);
-        MethodMessageConstants.TypeException exception = MethodMessageConstants.MESSAGES.multiProperty();
+        MethodMessageConstantsTypeException exception = MethodMessageConstants.MESSAGES.multiProperty();
         Assertions.assertEquals(String.class, exception.type);
         Assertions.assertEquals(MethodMessageConstants.stringTest, exception.value);
         exception = MethodMessageConstants.MESSAGES.repeatableProperty();
@@ -146,7 +148,7 @@ public class MessagesTest {
         Assertions.assertEquals(Long.MAX_VALUE, MethodMessageConstants.MESSAGES.longField().value);
         Assertions.assertEquals(Short.MAX_VALUE, MethodMessageConstants.MESSAGES.shortField().value);
         Assertions.assertEquals(MethodMessageConstants.stringTest, MethodMessageConstants.MESSAGES.stringField().value);
-        MethodMessageConstants.TypeException exception = MethodMessageConstants.MESSAGES.multiField();
+        MethodMessageConstantsTypeException exception = MethodMessageConstants.MESSAGES.multiField();
         Assertions.assertEquals(String.class, exception.type);
         Assertions.assertEquals(MethodMessageConstants.stringTest, exception.value);
         exception = MethodMessageConstants.MESSAGES.repeatableField();
@@ -171,11 +173,11 @@ public class MessagesTest {
 
         // Test suppliers with fields/properties
         int value = 5;
-        Supplier<CustomException> customExceptionSupplier = ValidMessages.MESSAGES.fieldMessageSupplier(value);
+        Supplier<ValidMessagesCustomException> customExceptionSupplier = ValidMessages.MESSAGES.fieldMessageSupplier(value);
         Assertions.assertNotNull(customExceptionSupplier);
-        CustomException customException = customExceptionSupplier.get();
+        ValidMessagesCustomException customException = customExceptionSupplier.get();
         Assertions.assertEquals(FORMATTED_TEST_MSG, customException.getMessage());
-        Assertions.assertEquals(CustomException.class, customException.getClass());
+        Assertions.assertEquals(ValidMessagesCustomException.class, customException.getClass());
         Assertions.assertEquals(value, customException.value);
 
         value = 20;
@@ -183,7 +185,7 @@ public class MessagesTest {
         Assertions.assertNotNull(customExceptionSupplier);
         customException = customExceptionSupplier.get();
         Assertions.assertEquals(FORMATTED_TEST_MSG, customException.getMessage());
-        Assertions.assertEquals(CustomException.class, customException.getClass());
+        Assertions.assertEquals(ValidMessagesCustomException.class, customException.getClass());
         Assertions.assertEquals(value, customException.value);
 
     }
@@ -204,15 +206,16 @@ public class MessagesTest {
 
         // Test functions with fields/properties
         int value = 5;
-        CustomException customException = ValidMessages.MESSAGES.fieldMessageFunction(CustomException::new, value);
+        ValidMessagesCustomException customException = ValidMessages.MESSAGES
+                .fieldMessageFunction(ValidMessagesCustomException::new, value);
         Assertions.assertEquals(FORMATTED_TEST_MSG, customException.getMessage());
-        Assertions.assertEquals(CustomException.class, customException.getClass());
+        Assertions.assertEquals(ValidMessagesCustomException.class, customException.getClass());
         Assertions.assertEquals(customException.value, value);
 
         value = 20;
-        customException = ValidMessages.MESSAGES.propertyMessageFunction(CustomException::new, value);
+        customException = ValidMessages.MESSAGES.propertyMessageFunction(ValidMessagesCustomException::new, value);
         Assertions.assertEquals(FORMATTED_TEST_MSG, customException.getMessage());
-        Assertions.assertEquals(CustomException.class, customException.getClass());
+        Assertions.assertEquals(ValidMessagesCustomException.class, customException.getClass());
         Assertions.assertEquals(value, customException.value);
     }
 
@@ -225,8 +228,8 @@ public class MessagesTest {
         Assertions.assertEquals(String.format(ValidMessages.TEST_OP_FAILED_MSG, "start"), runtimeException.getMessage());
         Assertions.assertEquals(cause, runtimeException.getCause());
 
-        runtimeException = ValidMessages.MESSAGES.throwableStringBiFunction(LoggingException::new, cause);
-        Assertions.assertEquals(LoggingException.class, runtimeException.getClass());
+        runtimeException = ValidMessages.MESSAGES.throwableStringBiFunction(ValidMessagesLoggingException::new, cause);
+        Assertions.assertEquals(ValidMessagesLoggingException.class, runtimeException.getClass());
         Assertions.assertEquals(cause, runtimeException.getCause());
 
         final Supplier<RuntimeException> supplier = ValidMessages.MESSAGES

--- a/processor/src/test/java/org/jboss/logging/processor/generated/tests/ThrowableSignatureTest.java
+++ b/processor/src/test/java/org/jboss/logging/processor/generated/tests/ThrowableSignatureTest.java
@@ -20,9 +20,9 @@
 package org.jboss.logging.processor.generated.tests;
 
 import org.jboss.logging.processor.generated.SignatureMessages;
-import org.jboss.logging.processor.generated.SignatureMessages.InvalidTextException;
-import org.jboss.logging.processor.generated.SignatureMessages.RedirectException;
-import org.jboss.logging.processor.generated.SignatureMessages.TestException;
+import org.jboss.logging.processor.generated.SignatureMessagesInvalidTextException;
+import org.jboss.logging.processor.generated.SignatureMessagesRedirectException;
+import org.jboss.logging.processor.generated.SignatureMessagesTestException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -39,25 +39,27 @@ public class ThrowableSignatureTest {
 
         final int code = 307;
         final String location = "foo";
-        RedirectException redirectExpected = new RedirectException(formattedMessage, code, location);
+        SignatureMessagesRedirectException redirectExpected = new SignatureMessagesRedirectException(formattedMessage, code,
+                location);
         Assertions.assertEquals(redirectExpected, SignatureMessages.MESSAGES.redirect(code, location));
-        redirectExpected = new RedirectException(formattedMessage, location);
+        redirectExpected = new SignatureMessagesRedirectException(formattedMessage, location);
         redirectExpected.initCause(cause);
         Assertions.assertEquals(redirectExpected, SignatureMessages.MESSAGES.redirect(cause, location));
-        redirectExpected = new RedirectException(formattedMessage, cause, code, location);
+        redirectExpected = new SignatureMessagesRedirectException(formattedMessage, cause, code, location);
         Assertions.assertEquals(redirectExpected, SignatureMessages.MESSAGES.redirect(cause, code, location));
 
-        TestException testExpected = new TestException(formattedMessage);
+        SignatureMessagesTestException testExpected = new SignatureMessagesTestException(formattedMessage);
         Assertions.assertEquals(testExpected, SignatureMessages.MESSAGES.test());
-        testExpected = new TestException(formattedMessage, cause);
+        testExpected = new SignatureMessagesTestException(formattedMessage, cause);
         Assertions.assertEquals(testExpected, SignatureMessages.MESSAGES.test(cause));
 
         final String invalidText = "invalid";
-        InvalidTextException invalidTextExpected = new InvalidTextException(formattedMessage, invalidText);
+        SignatureMessagesInvalidTextException invalidTextExpected = new SignatureMessagesInvalidTextException(formattedMessage,
+                invalidText);
         Assertions.assertEquals(invalidTextExpected, SignatureMessages.MESSAGES.invalidText(invalidText));
-        invalidTextExpected = new InvalidTextException(formattedMessage, cause, invalidText);
+        invalidTextExpected = new SignatureMessagesInvalidTextException(formattedMessage, cause, invalidText);
         Assertions.assertEquals(invalidTextExpected, SignatureMessages.MESSAGES.invalidText(cause, invalidText));
-        invalidTextExpected = new InvalidTextException(3, cause, invalidText, formattedMessage);
+        invalidTextExpected = new SignatureMessagesInvalidTextException(3, cause, invalidText, formattedMessage);
         Assertions.assertEquals(invalidTextExpected, SignatureMessages.MESSAGES.invalidText(3, cause, invalidText));
     }
 }


### PR DESCRIPTION
Hey @jamezp 

with the most recent release of `[plexus-compiler](https://github.com/codehaus-plexus/plexus-compiler)` and in particular after this fix: https://github.com/codehaus-plexus/plexus-compiler/pull/350  we've started to see build failures with:

```java
[ERROR] Unknown source: Cannot read org.hibernate.search.util.impl.test.logging package files, cause : java.io.FileNotFoundException: Resource does not exist : CLASS_OUTPUT/org.hibernate.search.util.impl.test.logging/Log
[ERROR] 	at org.eclipse.jdt.internal.compiler.apt.dispatch.BatchFilerImpl.getResource(BatchFilerImpl.java:173)
[ERROR] 	at org.jboss.logging.processor.apt.TranslationClassGenerator.findTranslationFiles(TranslationClassGenerator.java:152)
[ERROR] 	at org.jboss.logging.processor.apt.TranslationClassGenerator.processTypeElement(TranslationClassGenerator.java:115)
[ERROR] 	at org.jboss.logging.processor.apt.LoggingToolsProcessor.doProcess(LoggingToolsProcessor.java:213)
[ERROR] 	at org.jboss.logging.processor.apt.LoggingToolsProcessor.process(LoggingToolsProcessor.java:167)
[ERROR] 	at org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.handleProcessor(RoundDispatcher.java:141)
[ERROR] 	at org.eclipse.jdt.internal.compiler.apt.dispatch.RoundDispatcher.round(RoundDispatcher.java:123)
[ERROR] 	at org.eclipse.jdt.internal.compiler.apt.dispatch.BaseAnnotationProcessorManager.processAnnotations(BaseAnnotationProcessorManager.java:172)
[ERROR] 	at org.eclipse.jdt.internal.compiler.Compiler.processAnnotations(Compiler.java:952)
[ERROR] 	at org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:449)
[ERROR] 	at org.eclipse.jdt.internal.compiler.Compiler.compile(Compiler.java:425)
[ERROR] 	at org.eclipse.jdt.internal.compiler.batch.Main.performCompilation(Main.java:4753)
[ERROR] 	at org.eclipse.jdt.internal.compiler.tool.EclipseCompilerImpl.call(EclipseCompilerImpl.java:101)
[ERROR] 	at org.eclipse.jdt.internal.compiler.tool.EclipseCompiler$1.call(EclipseCompiler.java:196)
[ERROR] 	at org.codehaus.plexus.compiler.eclipse.EclipseJavaCompiler.performCompile(EclipseJavaCompiler.java:309)
[ERROR] 	at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:1188)
[ERROR] 	at org.apache.maven.plugin.compiler.CompilerMojo.execute(CompilerMojo.java:212)
[ERROR] 	at com.gradle.maven.cache.extension.d.c.a(SourceFile:27)
[ERROR] 	at com.gradle.maven.cache.extension.d.n.a(SourceFile:23)
[ERROR] 	at com.gradle.maven.cache.extension.d.h.a(SourceFile:28)
[ERROR] 	at com.gradle.maven.cache.extension.d.m.a(SourceFile:27)
[ERROR] 	at com.gradle.maven.cache.extension.d.a.c(SourceFile:115)
[ERROR] 	at com.gradle.maven.cache.extension.d.a.a(SourceFile:61)
[ERROR] 	at com.gradle.maven.cache.extension.d.e.a(SourceFile:27)
[ERROR] 	at com.gradle.maven.cache.extension.d.l.a(SourceFile:17)
[ERROR] 	at com.gradle.maven.cache.extension.d.d.a(SourceFile:42)
[ERROR] 	at com.gradle.maven.cache.extension.d.b.a(SourceFile:26)
[ERROR] 	at com.gradle.maven.cache.extension.d.f$1.run(SourceFile:35)
[ERROR] 	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(SourceFile:29)
[ERROR] 	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(SourceFile:26)
[ERROR] 	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(SourceFile:66)
[ERROR] 	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(SourceFile:59)
[ERROR] 	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(SourceFile:157)
[ERROR] 	at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(SourceFile:59)
[ERROR] 	at org.gradle.internal.operations.DefaultBuildOperationRunner.run(SourceFile:47)
[ERROR] 	at com.gradle.maven.cache.extension.d.f.a(SourceFile:31)
[ERROR] 	at com.gradle.maven.cache.extension.d.k.a(SourceFile:76)
[ERROR] 	at com.gradle.maven.cache.extension.h.b.lambda$createProxy$0(SourceFile:79)
[ERROR] 	at jdk.proxy10/jdk.proxy10.$Proxy78.execute(Unknown Source)
[ERROR] 	at com.gradle.maven.scan.extension.internal.d.a.executeMojo(SourceFile:114)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:328)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:316)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:174)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:75)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:162)
[ERROR] 	at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
[ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:159)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:105)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:73)
[ERROR] 	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:53)
[ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:118)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:261)
[ERROR] 	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:173)
[ERROR] 	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:101)
[ERROR] 	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:906)
[ERROR] 	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:283)
[ERROR] 	at org.apache.maven.cli.MavenCli.main(MavenCli.java:206)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[ERROR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:283)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:226)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:407)
[ERROR] 	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:348)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ERROR] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[ERROR] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ERROR] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[ERROR] 	at org.apache.maven.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:52)
[ERROR] 	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:161)
[ERROR] 	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:73)
[ERROR] 
```

e.g. https://ci.hibernate.org/blue/organizations/jenkins/hibernate-search/detail/main/1041/pipeline/121 
Let me know if the change makes sense to you. Thanks!