### PR TITLE
Add a module descriptor

### DIFF
--- a/annotations/src/main/java/module-info.java
+++ b/annotations/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module org.jboss.logging.annotations {
+    requires static org.jboss.logging;
+}


### PR DESCRIPTION
This adds a module descriptor for the annotation module. The proposed module name is `org.jboss.logging.annotations`.