### PR TITLE
[LOGTOOL-160] Fix skiping of rendering a Generated annotation

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/apt/MessageInterfaceFactory.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/MessageInterfaceFactory.java
@@ -139,10 +139,15 @@ public final class MessageInterfaceFactory {
             } else {
                 validIdRanges = Collections.emptyList();
             }
-            // Determine the type for the generated annotation
-            final ModuleElement moduleElement = processingEnv.getElementUtils()
-                    .getModuleElement(Generated.class.getModule().getName());
-            this.generatedAnnotation = processingEnv.getElementUtils().getTypeElement(moduleElement, Generated.class.getName());
+            if (addGeneratedAnnotation) {
+                // Determine the type for the generated annotation
+                final ModuleElement moduleElement = processingEnv.getElementUtils()
+                        .getModuleElement(Generated.class.getModule().getName());
+                this.generatedAnnotation = processingEnv.getElementUtils().getTypeElement(moduleElement,
+                        Generated.class.getName());
+            } else {
+                this.generatedAnnotation = null;
+            }
         }
 
         @Override


### PR DESCRIPTION
Hey @jamezp !

It's me again 😄. This PR is similar to https://github.com/jboss-logging/jboss-logging-tools/pull/81. 

This came up from a discussion at reproducible-central: https://github.com/jvm-repo-rebuild/reproducible-central/pull/178#issuecomment-2159889678

The build of Hibernate Search is reproducible in terms of produced jars, but as for sources - because of the generated classes the timestamp is causing a bit of a problem. 

I've noticed that there was this `org.jboss.logging.tools.addGeneratedAnnotation` option and thought we could use it, but from what it seems, the option wasn't really making a difference 😕 😔. So while I've added a suggested patch to fix that I've also included a way for a user to override how the value of `@Generated(date =?)` is rendered.... 

Let me know if it makes sense, and if so, I'll add something to the docs for the new options ... Thanks!