### PR TITLE
JBLOGGING-186 - Allow jboss-logging-processor to operate as an incremental processor in Gradle builds

### DIFF
--- a/processor/src/main/resources/META-INF/services/gradle/incremental.annotation.processors
+++ b/processor/src/main/resources/META-INF/services/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+org.jboss.logging.processor.apt.LoggingToolsProcessor,isolating


### PR DESCRIPTION
JBLOGGING-186 - Allow jboss-logging-processor to operate as an incremental processor in Gradle builds