### PR TITLE
Fixes potential NPE while reading annotations

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/apt/MessageMethodBuilder.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/MessageMethodBuilder.java
@@ -370,7 +370,8 @@ final class MessageMethodBuilder {
         @Override
         public Set<Parameter> parametersAnnotatedWith(final Class<? extends Annotation> annotation) {
             final TypeElement type = ElementHelper.toTypeElement(elements, annotation);
-            return parameters.containsKey(type.asType()) ? Collections.unmodifiableSet(parameters.get(type.asType()))
+            return (type != null && parameters.containsKey(type.asType()))
+                    ? Collections.unmodifiableSet(parameters.get(type.asType()))
                     : Collections.emptySet();
         }
 


### PR DESCRIPTION
An NPE may happen in methods returning an exception without the `@TransformException` annotation

```
[ERROR] java.lang.NullPointerException: Cannot invoke "javax.lang.model.element.TypeElement.asType()" because "type" is null
  	at org.jboss.logging.processor.apt.MessageMethodBuilder$AptMessageMethod.parametersAnnotatedWith(MessageMethodBuilder.java:373)
  	at org.jboss.logging.processor.apt.ThrowableTypeFactory$AptReturnThrowableType.init(ThrowableTypeFactory.java:328)
  	at org.jboss.logging.processor.apt.ThrowableTypeFactory.forReturnType(ThrowableTypeFactory.java:73)
  	at org.jboss.logging.processor.apt.ReturnTypeFactory$AptReturnType.init(ReturnTypeFactory.java:141)
  	at org.jboss.logging.processor.apt.ReturnTypeFactory.of(ReturnTypeFactory.java:61)
  	at org.jboss.logging.processor.apt.MessageMethodBuilder.build(MessageMethodBuilder.java:118)
  	at org.jboss.logging.processor.apt.MessageInterfaceFactory$AptMessageInterface.init(MessageInterfaceFactory.java:191)
  	at org.jboss.logging.processor.apt.MessageInterfaceFactory.of(MessageInterfaceFactory.java:100)
  	at org.jboss.logging.processor.apt.LoggingToolsProcessor.doProcess(LoggingToolsProcessor.java:200)
  	at org.jboss.logging.processor.apt.LoggingToolsProcessor.process(LoggingToolsProcessor.java:165)
```
- See https://github.com/quarkiverse/quarkus-ironjacamar/pull/117#issuecomment-2206014335
