### PR TITLE
Export `org.jboss.logging.annotations`

### DIFF
--- a/annotations/src/main/java/module-info.java
+++ b/annotations/src/main/java/module-info.java
@@ -1,3 +1,4 @@
 module org.jboss.logging.annotations {
     requires static org.jboss.logging;
+    exports org.jboss.logging.annotations;
 }


### PR DESCRIPTION
Otherwise no modules can use it.