### PR TITLE
More fixes for module mode

### DIFF
--- a/annotations/src/main/java/module-info.java
+++ b/annotations/src/main/java/module-info.java
@@ -1,4 +1,4 @@
 module org.jboss.logging.annotations {
-    requires static org.jboss.logging;
+    requires org.jboss.logging;
     exports org.jboss.logging.annotations;
 }

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/processor/src/main/java/org/jboss/logging/processor/apt/MessageInterfaceFactory.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/MessageInterfaceFactory.java
@@ -143,8 +143,9 @@ public final class MessageInterfaceFactory {
                 // Determine the type for the generated annotation
                 final ModuleElement moduleElement = processingEnv.getElementUtils()
                         .getModuleElement(Generated.class.getModule().getName());
-                this.generatedAnnotation = processingEnv.getElementUtils().getTypeElement(moduleElement,
-                        Generated.class.getName());
+                this.generatedAnnotation = moduleElement == null
+                        ? processingEnv.getElementUtils().getTypeElement(Generated.class.getName())
+                        : processingEnv.getElementUtils().getTypeElement(moduleElement, Generated.class.getName());
             } else {
                 this.generatedAnnotation = null;
             }


### PR DESCRIPTION
Fixes a problem where the annotation processor cannot be instantiated in a modular application. Also fixes this exception which occurs in module mode:

```
java.lang.NullPointerException: Cannot invoke "javax.lang.model.element.ModuleElement.getClass()" because "module" is null
  	at jdk.compiler/com.sun.tools.javac.model.JavacElements.getTypeElement(JavacElements.java:167)
  	at jdk.compiler/com.sun.tools.javac.model.JavacElements.getTypeElement(JavacElements.java:88)
  	at org.jboss.logging.processor.apt.MessageInterfaceFactory$AptMessageInterface.<init>(MessageInterfaceFactory.java:146)
  	at org.jboss.logging.processor.apt.MessageInterfaceFactory.of(MessageInterfaceFactory.java:98)
  	at org.jboss.logging.processor.apt.LoggingToolsProcessor.doProcess(LoggingToolsProcessor.java:200)
  	at org.jboss.logging.processor.apt.LoggingToolsProcessor.process(LoggingToolsProcessor.java:165)
  	(...)
```