### PR TITLE
JBLOGGING-189 Include originating element when creating files with Filer

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/apt/ReportFileGenerator.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/ReportFileGenerator.java
@@ -35,6 +35,7 @@ import java.util.TreeSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.StandardLocation;
 
@@ -98,7 +99,8 @@ public class ReportFileGenerator extends AbstractGenerator {
 
                 final String fileName = messageInterface.simpleName() + reportType.getExtension();
                 try (
-                        final BufferedWriter writer = createWriter(messageInterface.packageName(), fileName);
+                        final BufferedWriter writer = createWriter(messageInterface.packageName(), fileName,
+                                processingEnv.getElementUtils().getTypeElement(messageInterface.name()));
                         final ReportWriter reportWriter = ReportWriter.of(reportType, messageInterface, writer)) {
                     reportWriter.writeHeader(reportTitle);
                     // Process the methods
@@ -113,10 +115,11 @@ public class ReportFileGenerator extends AbstractGenerator {
         }
     }
 
-    private BufferedWriter createWriter(final String packageName, final String fileName) throws IOException {
+    private BufferedWriter createWriter(final String packageName, final String fileName, Element originatingElement)
+            throws IOException {
         if (reportPath == null) {
             return new BufferedWriter(processingEnv.getFiler()
-                    .createResource(StandardLocation.SOURCE_OUTPUT, packageName, fileName).openWriter());
+                    .createResource(StandardLocation.SOURCE_OUTPUT, packageName, fileName, originatingElement).openWriter());
         }
         final Path outputPath = Paths.get(reportPath, packageName.replace(".", FileSystems.getDefault().getSeparator()),
                 fileName);

--- a/processor/src/main/java/org/jboss/logging/processor/apt/TranslationFileGenerator.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/TranslationFileGenerator.java
@@ -211,7 +211,8 @@ final class TranslationFileGenerator extends AbstractGenerator {
         try {
             if (generatedFilesPath == null) {
                 final FileObject fileObject = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT,
-                        messageInterface.packageName(), fileName);
+                        messageInterface.packageName(), fileName,
+                        processingEnv.getElementUtils().getTypeElement(messageInterface.name()));
                 // Note the FileObject#openWriter() is used here. The FileObject#openOutputStream() returns an output stream
                 // that writes each byte separately which results in poor performance.
                 writer = new BufferedWriter(fileObject.openWriter());


### PR DESCRIPTION
https://issues.redhat.com/browse/JBLOGGING-189

and here's an example based on Hibernate ORM build:

#### Without the patch:
```
> Task :hibernate-core:compileJava
Build cache key for task ':hibernate-core:compileJava' is 9179d4b00e8baddeb848f63a0795416c
Task ':hibernate-core:compileJava' is not up-to-date because:
  Input property 'stableSources' file /home/marko/development/projects/opensource/hibernate-orm/hibernate-core/src/main/java/org/hibernate/cache/CacheException.java has changed.
Created classpath snapshot for incremental compilation in 0.004 secs.
Full recompilation is required because the generated resource 'org/hibernate/dialect/DialectLogging.i18n.properties in CLASS_OUTPUT' must have exactly one originating element, but had 0. Analysis took 0.073 secs.
Compiling with toolchain '/home/marko/.sdkman/candidates/java/21.0.3'.
Log level has changed, stopping idle worker daemon with out-of-date log level.

BUILD SUCCESSFUL in 1m 4s
110 actionable tasks: 9 executed, 101 up-to-date
```

#### With the patch:
```
> Task :hibernate-core:compileJava
Build cache key for task ':hibernate-core:compileJava' is 26a02c1fbcf88249babe7df8000b2289
Task ':hibernate-core:compileJava' is not up-to-date because:
  Input property 'stableSources' file /home/marko/development/projects/opensource/hibernate-orm/hibernate-core/src/main/java/org/hibernate/cache/CacheException.java has changed.
Created classpath snapshot for incremental compilation in 0.004 secs.
Compiling with toolchain '/home/marko/.sdkman/candidates/java/21.0.3-amzn'.
Log level has changed, stopping idle worker daemon with out-of-date log level.

Incremental compilation of 544 classes completed in 9.531 secs.
Class dependency analysis for incremental compilation took 0.04 secs.


BUILD SUCCESSFUL in 40s
110 actionable tasks: 9 executed, 101 up-to-date
```