### PR TITLE
Add a way to override how the @Generated(date=?) is rendered

### DIFF
--- a/processor/src/main/java/org/jboss/logging/processor/apt/LoggingToolsProcessor.java
+++ b/processor/src/main/java/org/jboss/logging/processor/apt/LoggingToolsProcessor.java
@@ -81,12 +81,17 @@ import org.jboss.logging.processor.validation.Validator;
         LoggingToolsProcessor.DEBUG_OPTION,
         LoggingToolsProcessor.EXPRESSION_PROPERTIES,
         LoggingToolsProcessor.ADD_GENERATED_ANNOTATION,
+        LoggingToolsProcessor.GENERATED_DATE_VALUE_PROVIDER,
+        LoggingToolsProcessor.GENERATED_DATE_VALUE_PROVIDER_DATE
 })
 public class LoggingToolsProcessor extends AbstractProcessor {
 
     public static final String DEBUG_OPTION = "debug";
     static final String EXPRESSION_PROPERTIES = "org.jboss.logging.tools.expressionProperties";
     static final String ADD_GENERATED_ANNOTATION = "org.jboss.logging.tools.addGeneratedAnnotation";
+    public static final String GENERATED_DATE_VALUE_PROVIDER = "org.jboss.logging.tools.generatedDateValueProvider";
+    public static final String GENERATED_DATE_VALUE_PROVIDER_DATE = "org.jboss.logging.tools.generatedDateValueProvider.date";
+
     private final List<String> interfaceAnnotations = Arrays.asList(MessageBundle.class.getName(),
             MessageLogger.class.getName());
     private final List<AbstractGenerator> generators;

--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/ClassModel.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/ClassModel.java
@@ -81,6 +81,7 @@ public abstract class ClassModel {
     private final String format;
 
     private final Map<String, JMethodDef> messageMethods;
+    private final GeneratedDateValueProvider generatedDateValueProvider;
 
     final JSourceFile sourceFile;
     final ProcessingEnvironment processingEnv;
@@ -112,6 +113,7 @@ public abstract class ClassModel {
             format = "%s%d: %s";
         }
         messageMethods = new HashMap<>();
+        generatedDateValueProvider = GeneratedDateValueProvider.of(processingEnv.getOptions());
     }
 
     /**
@@ -150,7 +152,7 @@ public abstract class ClassModel {
             sourceFile._import(generatedType);
             classDef.annotate(generatedType)
                     .value("value", getClass().getName())
-                    .value("date", JExprs.str(ClassModelHelper.generatedDateValue()));
+                    .value("date", JExprs.str(generatedDateValueProvider.date()));
         }
 
         // Create the default JavaDoc

--- a/processor/src/main/java/org/jboss/logging/processor/generator/model/GeneratedDateValueProvider.java
+++ b/processor/src/main/java/org/jboss/logging/processor/generator/model/GeneratedDateValueProvider.java
@@ -1,0 +1,72 @@
+package org.jboss.logging.processor.generator.model;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.jboss.logging.processor.apt.LoggingToolsProcessor;
+
+public abstract class GeneratedDateValueProvider {
+    enum Type {
+        DEFAULT,
+        NONE,
+        FIXED;
+    }
+
+    abstract String date();
+
+    public static GeneratedDateValueProvider of(Map<String, String> options) {
+        Type type = Type.valueOf(options.getOrDefault(LoggingToolsProcessor.GENERATED_DATE_VALUE_PROVIDER, Type.DEFAULT.name())
+                .toUpperCase(Locale.ROOT));
+        switch (type) {
+            case DEFAULT:
+                return DefaultGeneratedDateValueProvider.INSTANCE;
+            case NONE:
+                return NoneGeneratedDateValueProvider.INSTANCE;
+            case FIXED:
+                String date = options.get(LoggingToolsProcessor.GENERATED_DATE_VALUE_PROVIDER_DATE);
+                if (date == null) {
+                    throw new IllegalArgumentException(
+                            "Fixed date generated date value provider is requested, but the date is not specified. "
+                                    + "Use " + LoggingToolsProcessor.GENERATED_DATE_VALUE_PROVIDER_DATE
+                                    + " annotation processor option to provide the date.");
+                }
+                return new FixedGeneratedDateValueProvider(date);
+            default:
+                throw new IllegalStateException("Unknown generated date value provider type: " + type);
+        }
+    }
+
+    private static class DefaultGeneratedDateValueProvider extends GeneratedDateValueProvider {
+
+        private static final DefaultGeneratedDateValueProvider INSTANCE = new DefaultGeneratedDateValueProvider();
+
+        @Override
+        String date() {
+            return ClassModelHelper.generatedDateValue();
+        }
+    }
+
+    private static class NoneGeneratedDateValueProvider extends GeneratedDateValueProvider {
+
+        private static final NoneGeneratedDateValueProvider INSTANCE = new NoneGeneratedDateValueProvider();
+
+        @Override
+        String date() {
+            return "";
+        }
+    }
+
+    private static class FixedGeneratedDateValueProvider extends GeneratedDateValueProvider {
+
+        private final String date;
+
+        private FixedGeneratedDateValueProvider(String date) {
+            this.date = date;
+        }
+
+        @Override
+        String date() {
+            return date;
+        }
+    }
+}


### PR DESCRIPTION
Hey 👋🏻 🙂 

I found that old patch for the `@Generated#date()`. Let me know if you had a different idea on how to approach this one 🙂 